### PR TITLE
Epoch converter

### DIFF
--- a/src/chrono/io.cljc
+++ b/src/chrono/io.cljc
@@ -69,3 +69,20 @@
 (defn date-valid? [value fmt]
   #?(:clj true ; TODO
      :cljs (not (js/isNaN (.parse js/Date (format (parse value fmt) [:year "-" :month "-" :day]))))))
+
+(def epoch {:year 1970 :day 1 :month 1})
+
+(defn from-epoch [e]
+  (ops/plus {:sec e} epoch))
+
+(defn to-epoch [date]
+  (let [years (range (:year epoch) (:year date))
+        months (range 1 (:month date))]
+    (-> date
+        (dissoc :year :month)
+        (update :day #(reduce (fn [days year]
+                                (+ days (if (util/leap-year? year) 366 365))) % years))
+        (update :day #(reduce (fn [days month]
+                                (+ days (util/days-in-month
+                                         {:month month :year (:year date)}))) % months))
+        util/seconds)))

--- a/src/chrono/util.cljc
+++ b/src/chrono/util.cljc
@@ -111,3 +111,9 @@
        str/join))
 
 (def pad-zero (partial pad-str \0))
+
+(defn seconds [d]
+  (+ (* (dec (:day d)) 60 60 24)
+     (* (:hour d) 60 60)
+     (* (:min d) 60)
+     (:sec d)))

--- a/test/chrono/io_test.clj
+++ b/test/chrono/io_test.clj
@@ -163,7 +163,7 @@
 
 (deftest from-epoch-test
   (is (= {:day 22, :month 4, :year 2020, :sec 40, :min 49, :hour 1} (sut/from-epoch 1587520180)))
-  (is (= {:day 1, :month 1, :year 1970, :sec 0, :min 0, :hour 0} (sut/from-epoch 0))))
+  (is (= {:day 1, :month 1, :year 1970} (sut/from-epoch 0))))
 
 (deftest to-epoch-test
   (is (= 1587520180 (sut/to-epoch {:day 22, :month 4, :year 2020, :sec 40, :min 49, :hour 1})))

--- a/test/chrono/io_test.clj
+++ b/test/chrono/io_test.clj
@@ -160,3 +160,11 @@
     (is (= "Март" (#'sut/format-str 3 [:month] :ru)))
     (is (= "Aug" (#'sut/format-str 8 [:month :short] :en)))
     (is (= "09" (#'sut/format-str 9 [:month :short] nil)))))
+
+(deftest from-epoch-test
+  (is (= {:day 22, :month 4, :year 2020, :sec 40, :min 49, :hour 1} (sut/from-epoch 1587520180)))
+  (is (= {:day 1, :month 1, :year 1970, :sec 0, :min 0, :hour 0} (sut/from-epoch 0))))
+
+(deftest to-epoch-test
+  (is (= 1587520180 (sut/to-epoch {:day 22, :month 4, :year 2020, :sec 40, :min 49, :hour 1})))
+  (is (= 0 (sut/to-epoch {:day 1, :month 1, :year 1970, :sec 0, :min 0, :hour 0}))))


### PR DESCRIPTION
Closes #10 
Currently can convert only positive unixtime, converting negative values will produce invalid results.
Think it's acceptable because most of timestamps used are positive.