### PR TITLE
ops/normalize: Add support of custom units

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ Pure clojure time made simple for clj & cljs
 (ch/= (ch/+ (now/utc) (now/tz-offset))
       (now/local)) ;; => true
 
+;; using custom units
+;; Add custom normalization method. Example for nanoseconds:
+(def normalize-ns (sut/gen-norm :ns :ms 1000000 0))
+(defmethod sut/normalize-rule :ns [_ t] (normalize-ns t))
+
+(sut/normalize {:ns 1000000000})  ;; => {:sec 1}
+(sut/plus {:ns 999999999} {:ns 1}) ;; => {:sec 1}
+(sut/plus {:ns 9999999} {:ns 999000001}) ;; => {:sec 1 :ms 9}
 
 ```
 

--- a/src/chrono/ops.cljc
+++ b/src/chrono/ops.cljc
@@ -61,7 +61,7 @@
   (normalize-d t))
 (defmethod normalize-rule :month [_ t]
   (normalize-m t))
-  
+
 (def defaults-units  [[:year 0] [:month 1] [:day 1] [:hour 0] [:min 0] [:sec 0] [:ms 0]])
 (defn custom-units [t]
   (let [units-to-ignore (into #{} (conj (map first defaults-units) :tz))
@@ -71,16 +71,14 @@
 (defn ordered-rules [t]
   (let [init [:ms :sec :min :hour :month]
         with-custom (apply conj (custom-units t) init)]
-    (conj with-custom :day)
-    ))
+    (conj with-custom :day)))
 
 (defn normalize [t]
   (let [rules (ordered-rules t)
         normalized-time (reduce (fn [t unit] (normalize-rule unit t)) t rules)]
     (->> normalized-time
          (remove (comp zero? val))
-         (into {})
-    )))
+         (into {}))))
 
 (defn- after? [t t']
   (loop [[[p s] & ps] defaults-units]

--- a/src/chrono/ops.cljc
+++ b/src/chrono/ops.cljc
@@ -70,9 +70,9 @@
 (defn normalize [t]
   (let [rules (ordered-rules t)
         normalized-time (reduce (fn [t unit] (normalize-rule unit t)) t rules)]
-    (->> normalized-time
-         (remove (comp zero? val))
-         (into {}))))
+    (into {}
+          (remove (comp zero? val))
+          normalized-time)))
 
 (defn- after? [t t']
   (loop [[[p s] & ps] defaults-units]

--- a/src/chrono/ops.cljc
+++ b/src/chrono/ops.cljc
@@ -49,18 +49,12 @@
 
 (defmulti normalize-rule (fn [unit _] unit))
 (defmethod normalize-rule :default [_ t] t)
-(defmethod normalize-rule :ms [_ t]
-  (normalize-ms t))
-(defmethod normalize-rule :sec [_ t]
-  (normalize-s t))
-(defmethod normalize-rule :min [_ t]
-  (normalize-mi t))
-(defmethod normalize-rule :hour [_ t]
-  (normalize-h t))
-(defmethod normalize-rule :day [_ t]
-  (normalize-d t))
-(defmethod normalize-rule :month [_ t]
-  (normalize-m t))
+(defmethod normalize-rule :ms [_ t] (normalize-ms t))
+(defmethod normalize-rule :sec [_ t] (normalize-s t))
+(defmethod normalize-rule :min [_ t] (normalize-mi t))
+(defmethod normalize-rule :hour [_ t] (normalize-h t))
+(defmethod normalize-rule :day [_ t] (normalize-d t))
+(defmethod normalize-rule :month [_ t] (normalize-m t))
 
 (def defaults-units  [[:year 0] [:month 1] [:day 1] [:hour 0] [:min 0] [:sec 0] [:ms 0]])
 (defn custom-units [t]

--- a/src/chrono/ops.cljc
+++ b/src/chrono/ops.cljc
@@ -47,18 +47,40 @@
       (assoc x :year y :month m :day d))
     x))
 
-(defn normalize [t]
-  (->> t
-       normalize-ms
-       normalize-s
-       normalize-mi
-       normalize-h
-       normalize-m
-       normalize-d
-       (remove (comp zero? val))
-       (into {})))
-
+(defmulti normalize-rule (fn [unit _] unit))
+(defmethod normalize-rule :default [_ t] t)
+(defmethod normalize-rule :ms [_ t]
+  (normalize-ms t))
+(defmethod normalize-rule :sec [_ t]
+  (normalize-s t))
+(defmethod normalize-rule :min [_ t]
+  (normalize-mi t))
+(defmethod normalize-rule :hour [_ t]
+  (normalize-h t))
+(defmethod normalize-rule :day [_ t]
+  (normalize-d t))
+(defmethod normalize-rule :month [_ t]
+  (normalize-m t))
+  
 (def defaults-units  [[:year 0] [:month 1] [:day 1] [:hour 0] [:min 0] [:sec 0] [:ms 0]])
+(defn custom-units [t]
+  (let [units-to-ignore (into #{} (conj (map first defaults-units) :tz))
+        current-units (into #{} (keys t))]
+    (into [] (remove units-to-ignore current-units))))
+
+(defn ordered-rules [t]
+  (let [init [:ms :sec :min :hour :month]
+        with-custom (apply conj (custom-units t) init)]
+    (conj with-custom :day)
+    ))
+
+(defn normalize [t]
+  (let [rules (ordered-rules t)
+        normalized-time (reduce (fn [t unit] (normalize-rule unit t)) t rules)]
+    (->> normalized-time
+         (remove (comp zero? val))
+         (into {})
+    )))
 
 (defn- after? [t t']
   (loop [[[p s] & ps] defaults-units]

--- a/test/chrono/ops_test.clj
+++ b/test/chrono/ops_test.clj
@@ -241,7 +241,27 @@
 
     (matcho/match
      (sut/plus {:year 2019, :month 12, :day 10, :hour 13, :min 17, :sec 50, :ms 911} {:hour 2})
-     {:year 2019, :month 12, :day 10, :hour 15, :min 17, :sec 50, :ms 911}))
+     {:year 2019, :month 12, :day 10, :hour 15, :min 17, :sec 50, :ms 911})
+    
+    (testing "with custom units"
+     (def normalize-ns (sut/gen-norm :ns :ms 1000000 0))
+     (defmethod sut/normalize-rule :ns [_ t] (normalize-ns t))
+    
+     (matcho/match
+      (sut/plus {:ns 10} {:ns 1})
+      {:ns 11})
+      
+     (matcho/match
+      (sut/plus {:ns 999999999} {:ns 1})
+      {:sec 1})
+      
+     (matcho/match
+      (sut/plus {:ns 9999999} {:ns 999000001})
+      {:sec 1 :ms 9})
+      
+     (matcho/match
+      (sut/plus {:year 2019 :month 12 :day 31 :hour 23 :min 59 :sec 59 :ns 999999999} {:ns 1})
+      {:year 2020 :month 1 :day 1})))
 
   (testing "-"
     (matcho/match


### PR DESCRIPTION
Implementation for https://github.com/HealthSamurai/chrono/issues/3

## How it works

You can add custom unit and set normalize rule for it:
```
(def normalize-ns (sut/gen-norm :ns :ms 1000000 0))
(defmethod sut/normalize-rule :ns [_ t] (normalize-ns t))

(sut/normalize {:ns 1000000000})  ;; => {:sec 1}
(sut/plus {:ns 999999999} {:ns 1}) ;; => {:sec 1}
(sut/plus {:ns 9999999} {:ns 999000001}) ;; => {:sec 1 :ms 9}
```

