### PR TITLE
Implement UTC support

### DIFF
--- a/src/chrono/ops.cljc
+++ b/src/chrono/ops.cljc
@@ -84,12 +84,13 @@
          (assoc :utc target-utc)))))
 
 (defn- after? [t t']
-  (loop [[[p s] & ps] defaults-units]
-    (let [tp (get t p s) tp' (get t' p s)]
-      (cond
-        (> tp tp') true
-        (= tp tp') (and (seq ps) (recur ps))
-        :else false))))
+  (let [t'-in-t-utc (to-utc t' (get t :utc 0))]
+    (loop [[[p s] & ps] defaults-units]
+      (let [tp (get t p s) tp' (get t'-in-t-utc p s)]
+        (cond
+          (> tp tp') true
+          (= tp tp') (and (seq ps) (recur ps))
+          :else false)))))
 
 (def ^{:private true} default-time {:year 0 :month 1 :day 1 :hour 0 :min 0 :sec 0 :ms 0})
 

--- a/src/chrono/ops.cljc
+++ b/src/chrono/ops.cljc
@@ -78,10 +78,15 @@
   ([t] (to-utc t 0))
   ([t target-utc]
    (let [utc-addend (- (get t :utc 0) target-utc)
-         new-hour (+ (get t :hour 0) utc-addend)]
+         new-hour (- (get t :hour 0) utc-addend)]
      (-> t
          (assoc :hour new-hour)
          (assoc :utc target-utc)))))
+
+(comment
+  (to-utc {:year 2011 :month 1 :day 1 :hour 0 :utc -2})
+  (to-utc {:year 2011 :month 1 :day 1 :hour 3 :utc 1})
+  (to-utc {:hour 17 :utc 3} 0))
 
 (defn- after? [t t']
   (let [t'-in-t-utc (to-utc t' (get t :utc 0))]

--- a/src/chrono/ops.cljc
+++ b/src/chrono/ops.cljc
@@ -82,6 +82,7 @@
      (-> t
          (assoc :hour new-hour)
          (assoc :utc target-utc)))))
+
 (defn- after? [t t']
   (loop [[[p s] & ps] defaults-units]
     (let [tp (get t p s) tp' (get t' p s)]
@@ -109,7 +110,7 @@
    (reduce plus (plus x y) more)))
 
 (defn eq? [& ts]
-  (apply = (map normalize ts)))
+  (apply = (map (fn [t] (normalize (to-utc t))) ts)))
 
 (def not-eq? (complement eq?))
 

--- a/test/chrono/ops_test.clj
+++ b/test/chrono/ops_test.clj
@@ -301,7 +301,7 @@
 
       (matcho/match
         (sut/plus {:hour 2 :utc 1} {:hour 2})
-        {:hour 5 :utc 1})
+        {:hour 4 :utc 1})
 
       (matcho/match
         (sut/plus {:hour 2} {:hour 2 :utc 1})

--- a/test/chrono/ops_test.clj
+++ b/test/chrono/ops_test.clj
@@ -33,7 +33,13 @@
                       {:year 2011 :month 1 :day 1 :hour 0})))
     (is (sut/eq? {:year 2011 :month 1 :day 1 :hour 0}
                  {:year 2011 :month 1 :day 1 :hour 0}
-                 {:year 2011 :month 1 :day 1 :hour 0})))
+                 {:year 2011 :month 1 :day 1 :hour 0}))
+
+    (testing "with utc"
+      (is (sut/eq? {:year 2011 :month 1 :day 1 :hour 0 :utc 2}
+               {:year 2011 :month 1 :day 1 :hour 1 :utc 1}
+               {:year 2011 :month 1 :day 1 :hour 3 :utc -1}))))
+
   (testing "not="
     (is (not (sut/not-eq? {:year 2011 :month 1 :day 1 :hour 0})))
     (is (not (sut/not-eq? {:year 2011 :month 1 :day 1 :hour 0}

--- a/test/chrono/ops_test.clj
+++ b/test/chrono/ops_test.clj
@@ -60,7 +60,16 @@
                 {:year 2011 :month 1 :day 1 :hour 0}))
     (is (sut/gt {:year 2011 :month 1 :day 2 :hour 0}
                 {:year 2011 :month 1 :day 1 :hour 1}
-                {:year 2011 :month 1 :day 1 :hour 0})))
+                {:year 2011 :month 1 :day 1 :hour 0}))
+
+    (testing "with utc"
+      (is (sut/gt {:year 2011 :month 1 :day 1 :hour 0 :utc 2}
+                  {:year 2011 :month 1 :day 1 :hour 0 :utc 1}
+                  {:year 2011 :month 1 :day 1 :hour 0 :utc -1}))
+      (is (not (sut/gt {:year 2011 :month 1 :day 1 :hour 0 :utc -1}
+                       {:year 2011 :month 1 :day 1 :hour 0 :utc 1}
+                       {:year 2011 :month 1 :day 1 :hour 0 :utc 2})))))
+
   (testing "<"
     (is (sut/lt {:year 2011 :month 1 :day 1 :hour 0}))
     (is (not (sut/lt {:year 2011 :month 1 :day 2 :hour 0}
@@ -69,7 +78,15 @@
                 {:year 2011 :month 1 :day 2 :hour 0}))
     (is (sut/lt {:year 2011 :month 1 :day 1 :hour 0}
                 {:year 2011 :month 1 :day 1 :hour 1}
-                {:year 2011 :month 1 :day 2 :hour 0})))
+                {:year 2011 :month 1 :day 2 :hour 0}))
+
+    (testing "with utc"
+      (is (sut/lt {:year 2011 :month 1 :day 1 :hour 0 :utc -1}
+                  {:year 2011 :month 1 :day 1 :hour 0 :utc 1}
+                  {:year 2011 :month 1 :day 1 :hour 0 :utc 2}))
+      (is (not (sut/lt {:year 2011 :month 1 :day 1 :hour 0 :utc 2}
+                       {:year 2011 :month 1 :day 1 :hour 0 :utc 1}
+                       {:year 2011 :month 1 :day 1 :hour 0 :utc -1})))))
   (testing "<="
     (is (sut/lte {:year 2011 :month 1 :day 1 :hour 0}))
     (is (sut/lte {:year 2011 :month 1 :day 1 :hour 0}
@@ -94,7 +111,7 @@
                  {:year 2011 :month 1 :day 1 :hour 0}
                  {:year 2011 :month 1 :day 1 :hour 0})))
 
-  (testing "tz comparsion"
+  (testing "tz comparison"
     (is (sut/lte {:year 2018 :month 5 :day 2 :hour 14 :tz :ny}
                  {:year 2018 :month 5 :day 2 :hour 14 :tz :ny}))
 

--- a/test/chrono/ops_test.clj
+++ b/test/chrono/ops_test.clj
@@ -18,8 +18,8 @@
   (is (= [2013 1 31] (sut/days-and-months 2013 1 31)))
   (is (= [2013 2 1] (sut/days-and-months 2013 1 32)))
 
-  (is (= [2012 1 1] (sut/days-and-months 2013 1 -365)))
-  )
+  (is (= [2012 1 1] (sut/days-and-months 2013 1 -365))))
+
 
 (deftest comparsion-operators-test
   (testing "="
@@ -261,7 +261,28 @@
       
      (matcho/match
       (sut/plus {:year 2019 :month 12 :day 31 :hour 23 :min 59 :sec 59 :ns 999999999} {:ns 1})
-      {:year 2020 :month 1 :day 1})))
+      {:year 2020 :month 1 :day 1}))
+
+    (testing "with utc"
+      (matcho/match
+        (sut/plus {:hour 2 :utc 1} {:hour 2 :utc 1})
+        {:hour 4 :utc 1})
+
+      (matcho/match
+        (sut/plus {:hour 2 :utc 1} {:hour 2 :utc 2})
+        {:hour 5 :utc 1})
+
+      (matcho/match
+        (sut/plus {:hour 2 :utc 1} {:hour 2 :utc -1})
+        {:hour 2 :utc 1})
+
+      (matcho/match
+        (sut/plus {:hour 2 :utc 1} {:hour 2})
+        {:hour 3 :utc 1})
+
+      (matcho/match
+        (sut/plus {:hour 2} {:hour 2 :utc 1})
+        {:hour 5})))
 
   (testing "-"
     (matcho/match

--- a/test/chrono/ops_test.clj
+++ b/test/chrono/ops_test.clj
@@ -36,9 +36,9 @@
                  {:year 2011 :month 1 :day 1 :hour 0}))
 
     (testing "with utc"
-      (is (sut/eq? {:year 2011 :month 1 :day 1 :hour 0 :utc 2}
-               {:year 2011 :month 1 :day 1 :hour 1 :utc 1}
-               {:year 2011 :month 1 :day 1 :hour 3 :utc -1}))))
+      (is (sut/eq? {:year 2011 :month 1 :day 1 :hour 0 :utc -2}
+                   {:year 2011 :month 1 :day 1 :hour 3 :utc 1}
+                   {:year 2011 :month 1 :day 1 :hour 4 :utc 2}))))
 
   (testing "not="
     (is (not (sut/not-eq? {:year 2011 :month 1 :day 1 :hour 0})))
@@ -63,12 +63,12 @@
                 {:year 2011 :month 1 :day 1 :hour 0}))
 
     (testing "with utc"
-      (is (sut/gt {:year 2011 :month 1 :day 1 :hour 0 :utc 2}
+      (is (sut/gt {:year 2011 :month 1 :day 1 :hour 0 :utc -2}
                   {:year 2011 :month 1 :day 1 :hour 0 :utc 1}
-                  {:year 2011 :month 1 :day 1 :hour 0 :utc -1}))
-      (is (not (sut/gt {:year 2011 :month 1 :day 1 :hour 0 :utc -1}
+                  {:year 2011 :month 1 :day 1 :hour 0 :utc 2}))
+      (is (not (sut/gt {:year 2011 :month 1 :day 1 :hour 0 :utc 2}
                        {:year 2011 :month 1 :day 1 :hour 0 :utc 1}
-                       {:year 2011 :month 1 :day 1 :hour 0 :utc 2})))))
+                       {:year 2011 :month 1 :day 1 :hour 0 :utc -2})))))
 
   (testing "<"
     (is (sut/lt {:year 2011 :month 1 :day 1 :hour 0}))
@@ -81,12 +81,12 @@
                 {:year 2011 :month 1 :day 2 :hour 0}))
 
     (testing "with utc"
-      (is (sut/lt {:year 2011 :month 1 :day 1 :hour 0 :utc -1}
+      (is (sut/lt {:year 2011 :month 1 :day 1 :hour 0 :utc 2}
                   {:year 2011 :month 1 :day 1 :hour 0 :utc 1}
-                  {:year 2011 :month 1 :day 1 :hour 0 :utc 2}))
-      (is (not (sut/lt {:year 2011 :month 1 :day 1 :hour 0 :utc 2}
+                  {:year 2011 :month 1 :day 1 :hour 0 :utc -2}))
+      (is (not (sut/lt {:year 2011 :month 1 :day 1 :hour 0 :utc -2}
                        {:year 2011 :month 1 :day 1 :hour 0 :utc 1}
-                       {:year 2011 :month 1 :day 1 :hour 0 :utc -1})))))
+                       {:year 2011 :month 1 :day 1 :hour 0 :utc 2})))))
   (testing "<="
     (is (sut/lte {:year 2011 :month 1 :day 1 :hour 0}))
     (is (sut/lte {:year 2011 :month 1 :day 1 :hour 0}
@@ -293,19 +293,19 @@
 
       (matcho/match
         (sut/plus {:hour 2 :utc 1} {:hour 2 :utc 2})
-        {:hour 5 :utc 1})
-
-      (matcho/match
-        (sut/plus {:hour 2 :utc 1} {:hour 2 :utc -1})
-        {:hour 2 :utc 1})
-
-      (matcho/match
-        (sut/plus {:hour 2 :utc 1} {:hour 2})
         {:hour 3 :utc 1})
 
       (matcho/match
+        (sut/plus {:hour 2 :utc 1} {:hour 2 :utc -1})
+        {:hour 6 :utc 1})
+
+      (matcho/match
+        (sut/plus {:hour 2 :utc 1} {:hour 2})
+        {:hour 5 :utc 1})
+
+      (matcho/match
         (sut/plus {:hour 2} {:hour 2 :utc 1})
-        {:hour 5})))
+        {:hour 3})))
 
   (testing "-"
     (matcho/match


### PR DESCRIPTION
Implementation of https://github.com/HealthSamurai/chrono/issues/1

### Limitations
`:utc`, for now, support integer values only. It means we did not support UTC+3:30, UTC+12:45 etc.