### PR TITLE
fix some typos

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,13 +1,13 @@
 {:paths ["src"]
- :deps {org.clojure/clojure     {:mvn/version "1.10.0-alpha4"}
+ :deps {org.clojure/clojure       {:mvn/version "1.10.0-alpha4"}
         org.clojure/clojurescript {:mvn/version "1.10.238"}}
 
  :aliases {:test
            {:extra-paths ["test"]
-            :extra-deps  { healthsamurai/matcho {:mvn/version "0.3.7"}}}
+            :extra-deps  {healthsamurai/matcho {:mvn/version "0.3.7"}}}
 
            :kaocha
-           {:extra-deps {lambdaisland/kaocha {:mvn/version "1.0-612"}}
+           {:extra-deps  {lambdaisland/kaocha {:mvn/version "1.0-612"}}
             :extra-paths ["test"]
             :jvm-opts    ^:replace ["-XX:-OmitStackTraceInFastThrow"]
             :main-opts   ["-m" "kaocha.runner" "--config-file" "test/test.edn"]}
@@ -16,10 +16,10 @@
            {:main-opts   ["-m" "kaocha.runner" "--profile" ":ci" "--config-file" "test/test.edn"]}
 
            :nrepl
-           {:extra-deps {cider/cider-nrepl {:mvn/version "0.25.0-SNAPSHOT"}
-                         refactor-nrepl    {:mvn/version "2.5.0"}
-                         cider/piggieback  {:mvn/version "0.4.2"}}
-            :main-opts  ["-m"           "nrepl.cmdline"
-                         "--middleware" "[cider.nrepl/cider-middleware]"
-                         "--port"       "55555"]
-            :jvm-opts   ^:replace ["-XX:-OmitStackTraceInFastThrow"]} }}
+           {:extra-deps  {cider/cider-nrepl {:mvn/version "0.25.0-SNAPSHOT"}
+                          refactor-nrepl    {:mvn/version "2.5.0"}
+                          cider/piggieback  {:mvn/version "0.4.2"}}
+            :main-opts   ["-m"           "nrepl.cmdline"
+                          "--middleware" "[cider.nrepl/cider-middleware]"
+                          "--port"       "55555"]
+            :jvm-opts    ^:replace ["-XX:-OmitStackTraceInFastThrow"]}}}

--- a/src/chrono/crono.cljc
+++ b/src/chrono/crono.cljc
@@ -4,7 +4,7 @@
             [chrono.util :as util]))
 
 (def needed-for
-  {:month [:yaer :month]
+  {:month [:year :month]
    :day [:year :month :day]
    :hour [:year :month :day :hour]
    :min [:year :month :day :hour :min]
@@ -67,9 +67,9 @@
     (prn (another-next-time n  cfg)))
 
 
-  (= {:year 2020 :month 5 :day 18 :hour 18})
-  (next-time #_(now/utc) {:year 2020 :month 5 :day 18 :hour 18 :min 44}
-             {:every "tuesday" :at {:hour 12 :min 10}})
+  (= {:year 2020 :month 5 :day 18 :hour 18}
+     (next-time #_(now/utc) {:year 2020 :month 5 :day 18 :hour 18 :min 44}
+                {:every "tuesday" :at {:hour 12 :min 10}}))
 
   (= {:year 2020 :month 1 :day 1 :hour 12}
      (next-time {:year 2020 :month 1 :day 1 :hour 11}


### PR DESCRIPTION
Fix a typo, indentation in `deps.edn` and nesting of commented out forms.