### PR TITLE
Types

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,65 +7,70 @@ Pure clojure time made simple for clj & cljs
 ## Usage
 
 ```clj
-(require '[chrono.core :as ch])
+(require '[chrono.core :as ch]
+         '[chrono.datetime :as cd]
+         '[chrono.interval :as ci])
 
 (def t
-  {:year  2018
-   :month 1
-   :day   29
-   :hour  10
-   :min   30
-   :sec   15
-   :tz    0})
+  #::cd{:year  2018
+        :month 1
+        :day   29
+        :hour  10
+        :min   30
+        :sec   15
+        :tz    0})
 
-(ch/+ t {:min 100})  ;; => {:year 2018, :month 1, :day 29, :hour 12, :min 10, :sec 15, :tz 0}
-(ch/+ t {:min -100}) ;; => {:year 2018, :month 1, :day 29, :hour 8, :min 50, :sec 15, :tz 0}
-;; also there is = not= > >= < <= -
+(ch/+ t {::ci/min 100})  ;; => #::cd{:year 2018, :month 1, :day 29, :hour 12, :min 10, :sec 15, :tz 0}
+(ch/+ t {::ci/min -100}) ;; => #::cd{:year 2018, :month 1, :day 29, :hour 8, :min 50, :sec 15, :tz 0}
+;; also there are = not= > >= < <= -
 
-(ch/normalize {:min 100}) ;; => {:min 40, :hour 1}
+(ch/normalize {::cd/min 100}) ;; => #::cd{:min 40, :hour 1}
 
-(def iso [:year \- :month \- :day \T :hour \: :min \: :sec])
+(def iso
+  [::cd/year \- ::cd/month \- ::cd/day \T
+   ::cd/hour \: ::cd/min \: ::cd/sec])
 (ch/format t iso) ;; => "2018-01-29T10:30:15"
-(ch/parse "2018-01-29T10:30:15" iso) ;; => {:year 2018, :month 1, :day 29, :hour 10, :min 30, :sec 15}
+(ch/parse "2018-01-29T10:30:15" iso) ;; => #::cd{:year 2018, :month 1, :day 29, :hour 10, :min 30, :sec 15}
 
-(ch/format t [:day "/" :month "/" :year]) ;; => "29/01/2018"
-(ch/parse  "2018.01.29"  [:year "." :month "." :day]) ;; => {:year 2018, :month 1, :day 29}
+(ch/format t [::cd/day "/" ::cd/month "/" ::cd/year]) ;; => "29/01/2018"
+(ch/parse "2018.01.29" [::cd/year "." ::cd/month "." ::cd/day]) ;; => {:year 2018, :month 1, :day 29}
 
 ;You can specify leading zero padding width by passing pairs [keyword number]
-(ch/format {:hour 1 :min 0 :sec 5} [[:hour 1] \: [:min 1] \: [:sec 1]]) ;; => "1:0:5"
+(ch/format #::cd{:hour 1 :min 0 :sec 5}
+           [[::cd/hour 1] \: [::cd/min 1] \: [::cd/sec 1]]) ;; => "1:0:5"
 
 (-> t
-    (ch/to-tz :ny) ;; => {:year 2018, :month 1, :day 29, :hour 5, :min 30, :sec 15, :tz :ny}
-    (ch/to-utc))   ;; => {:year 2018, :month 1, :day 29, :hour 10, :min 30, :sec 15, :tz :0}
+    (ch/to-tz :ny) ;; => #::cd{:year 2018, :month 1, :day 29, :hour 5, :min 30, :sec 15, :tz :ny}
+    (ch/to-utc))   ;; => #::cd{:year 2018, :month 1, :day 29, :hour 10, :min 30, :sec 15, :tz :0}
 ;; implement your tz with defmethod ch/day-saving :<your-tz>
 
 ;; You can use number as utc-offset
 (-> t
-    (ch/to-tz 3) ;; => {:year 2018, :month 1, :day 29, :hour 13, :min 30, :sec 15, :tz 3}
-    (ch/to-utc)) ;; => {:year 2018, :month 1, :day 29, :hour 10, :min 30, :sec 15, :tz 0}
+    (ch/to-tz 3) ;; => #::cd{:year 2018, :month 1, :day 29, :hour 13, :min 30, :sec 15, :tz 3}
+    (ch/to-utc)) ;; => #::cd{:year 2018, :month 1, :day 29, :hour 10, :min 30, :sec 15, :tz 0}
 
 (require '[chrono.now :as now])
 
-(now/local)     ;; => {:year 2019, :month 9, :day 18, :hour 1, :min 44, :sec 34, :ms 768, :tz 2}
-(now/utc)       ;; => {:year 2019, :month 9, :day 17, :hour 23, :min 44, :sec 34, :ms 768, :tz 0}
-(now/today)     ;; => {:year 2019, :month 9, :day 18, :tz 2}
-(now/utc-today) ;; => {:year 2019, :month 9, :day 17, :tz 0}
+(now/local)     ;; => #::cd{:year 2019, :month 9, :day 18, :hour 1, :min 44, :sec 34, :ms 768, :tz 2}
+(now/utc)       ;; => #::cd{:year 2019, :month 9, :day 17, :hour 23, :min 44, :sec 34, :ms 768, :tz 0}
+(now/today)     ;; => #::cd{:year 2019, :month 9, :day 18, :tz 2}
+(now/utc-today) ;; => #::cd{:year 2019, :month 9, :day 17, :tz 0}
 
-(now/tz-offset) ;; => {:hour 2}
+(now/tz-offset) ;; => #::ci{:hour 2}
 
 (ch/= (assoc (ch/+ (now/utc) (now/tz-offset))
-             :tz (:hour (now/tz-offset)))
+             ::cd/tz (::ci/hour (now/tz-offset)))
       (now/local)) ;; => true
 
 ;; using custom units
 ;; Add custom normalization method. Example for nanoseconds:
 (require '[chrono.ops :as ops])
-(def normalize-ns (ops/gen-norm :ns :ms 1000000 0))
-(defmethod ops/normalize-rule :ns [_ t] (normalize-ns t))
+(def normalize-ns (ops/gen-norm ::cd/ns ::cd/ms 1000000 0))
+(defmethod ops/normalize-rule ::cd/ns [_ t] (normalize-ns t))
 
-(ops/normalize {:ns 1000000000})  ;; => {:sec 1}
-(ops/plus {:ns 999999999} {:ns 1}) ;; => {:sec 1}
-(ops/plus {:ns 9999999} {:ns 999000001}) ;; => {:sec 1 :ms 9}
+(ops/normalize {::cd/ns 1000000000})             ;; => #::cd{:sec 1}
+(ops/plus {::cd/ns 999999999} {::ci/ns 1})       ;; => #::cd{:sec 1}
+(ops/plus {::cd/ns 9999999} {::ci/ns 999000001}) ;; => #::cd{:sec 1 :ms 9}
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ Pure clojure time made simple for clj & cljs
 (def normalize-ns (ops/gen-norm ::cd/ns ::cd/ms 1000000 0))
 (defmethod ops/normalize-rule ::cd/ns [_ t] (normalize-ns t))
 
-(ops/normalize {::cd/ns 1000000000})             ;; => #::cd{:sec 1}
-(ops/plus {::cd/ns 999999999} {::ci/ns 1})       ;; => #::cd{:sec 1}
-(ops/plus {::cd/ns 9999999} {::ci/ns 999000001}) ;; => #::cd{:sec 1 :ms 9}
+(ops/normalize {::cd/ns 1000000000}          ;; => #::cd{:sec 1}
+(ch/+ {::cd/ns 999999999} {::ci/ns 1})       ;; => #::cd{:sec 1}
+(ch/+ {::cd/ns 9999999} {::ci/ns 999000001}) ;; => #::cd{:sec 1 :ms 9}
 ```
 
 ## License

--- a/src/chrono/core.cljc
+++ b/src/chrono/core.cljc
@@ -4,12 +4,6 @@
             [chrono.io :as io])
   (:refer-clojure :exclude [+ - = > >= < <= not= format compare]))
 
-(defn datetime [t]
-  (merge {:type  :datetime
-          :year  1900
-          :month 1
-          :day   1} t))
-
 (def parse io/parse)
 (def format io/format)
 (def strict-parse io/strict-parse)
@@ -27,7 +21,7 @@
 (def date-valid? io/date-valid?)
 
 (def + ops/plus)
-(def - ops/minus) ; TODO: add tests
+(def - ops/minus)
 (def = ops/eq?)
 (def not= ops/not-eq?)
 (def eq? ops/eq?)

--- a/src/chrono/crono.cljc
+++ b/src/chrono/crono.cljc
@@ -36,7 +36,7 @@
   (assert (:every cfg) ":every must be specified")
   (assert (contains? #{::ci/month ::ci/day ::ci/hour ::ci/min :sunday :monday :tuesday :wednesday :thursday :friday :saturday}
                      (keyword (:every cfg)))
-          ":every must one of [ci/month ci/day ci/hour ci/min sunday monday tuesday wednesday thursday friday saturday]"))
+          ":every must one of [::ci/month ::ci/day ::ci/hour ::ci/min \"sunday\" \"monday\" \"tuesday\" \"wednesday\" \"thursday\" \"friday\" \"saturday\"]"))
 
 (defn next-time
   ([cfg] (next-time (now/utc) cfg))

--- a/src/chrono/crono.cljc
+++ b/src/chrono/crono.cljc
@@ -1,18 +1,20 @@
 (ns chrono.crono
   (:require [chrono.core :as ch]
+            [chrono.datetime :as cd]
+            [chrono.interval :as ci]
             [chrono.now :as now]
             [chrono.util :as util]))
 
 (def needed-for
-  {:month [:year :month]
-   :day [:year :month :day]
-   :hour [:year :month :day :hour]
-   :min [:year :month :day :hour :min]
-   :sec [:year :month :day :hour :min :sec]})
+  #::ci{:month [::cd/year ::cd/month]
+        :day [::cd/year ::cd/month ::cd/day]
+        :hour [::cd/year ::cd/month ::cd/day ::cd/hour]
+        :min [::cd/year ::cd/month ::cd/day ::cd/hour ::cd/min]
+        :sec [::cd/year ::cd/month ::cd/day ::cd/hour ::cd/min ::cd/sec]})
 
 (def default-at
-  {:hour {:min 0}
-   :min {:sec 0}})
+  #::ci{:hour {::cd/min 0}
+        :min {::cd/sec 0}})
 
 (defn next-time-assumption [current-time {every :every at :at}])
 
@@ -32,9 +34,9 @@
 
 (defn validate-cfg [cfg]
   (assert (:every cfg) ":every must be specified")
-  (assert (contains? #{:month :day :hour :min :sunday :monday :tuesday :wednesday :thursday :friday :saturday}
+  (assert (contains? #{::ci/month ::ci/day ::ci/hour ::ci/min :sunday :monday :tuesday :wednesday :thursday :friday :saturday}
                      (keyword (:every cfg)))
-          ":every must one of [month day hour min sunday monday tuesday wednesday thursday friday saturday]"))
+          ":every must one of [ci/month ci/day ci/hour ci/min sunday monday tuesday wednesday thursday friday saturday]"))
 
 (defn next-time
   ([cfg] (next-time (now/utc) cfg))
@@ -43,10 +45,10 @@
    (if (contains? (set days-of-week) (keyword (:every cfg)))
      (first
       (filter
-       #(= (util/day-of-week (:year %) (:month %) (:day %))
+       #(= (util/day-of-week (::cd/year %) (::cd/month %) (::cd/day %))
            (.indexOf days-of-week (keyword (:every cfg))))
        (drop 1 (iterate
-                (fn [current-time] (*next-time current-time (assoc cfg :every :day)))
+                (fn [current-time] (*next-time current-time (assoc cfg :every ::ci/day)))
                 current-time))))
      (*next-time current-time cfg))))
 

--- a/src/chrono/datetime.cljc
+++ b/src/chrono/datetime.cljc
@@ -1,0 +1,1 @@
+(ns chrono.datetime)

--- a/src/chrono/interval.cljc
+++ b/src/chrono/interval.cljc
@@ -1,0 +1,1 @@
+(ns chrono.interval)

--- a/src/chrono/io.cljc
+++ b/src/chrono/io.cljc
@@ -75,7 +75,7 @@
 
 (defn date-valid? [value fmt]
   #?(:clj true ; TODO
-     :cljs (not (js/isNaN (.parse js/Date (format (parse value fmt) [:year "-" :month "-" :day]))))))
+     :cljs (not (js/isNaN (.parse js/Date (format (parse value fmt) [::cd/year "-" ::cd/month "-" ::cd/day])))))) ;; TODO: remove interop, move to chrono.util
 
 (def epoch #::cd{:year 1970 :day 1 :month 1})
 

--- a/src/chrono/locale_ru.cljc
+++ b/src/chrono/locale_ru.cljc
@@ -1,8 +1,9 @@
 (ns chrono.locale-ru
-  (:require [chrono.util :as util]))
+  (:require [chrono.util :as util]
+            [chrono.datetime :as cd]))
 
 (defmethod util/locale :ru [_]
-  {:month
+  {::cd/month
    {1 {:name "Январь", :short "Янв", :regex "(?iu)янв(ар(ь|я))?"}
     2 {:name "Февраль", :short "Фев", :regex "(?iu)фев(рал(ь|я))?"}
     3 {:name "Март", :short "Мар", :regex "(?iu)мар(та?)?"}

--- a/src/chrono/now.cljc
+++ b/src/chrono/now.cljc
@@ -1,60 +1,62 @@
 (ns chrono.now
-  (:require [chrono.ops :as ops]))
+  (:require [chrono.ops :as ops]
+            [chrono.datetime :as cd]
+            [chrono.interval :as ci]))
 
 (defn tz-offset []
   #?(:clj (-> (java.time.ZonedDateTime/now)
               .getOffset
               .getTotalSeconds
-              (->> (hash-map :sec))
+              (->> (hash-map ::ci/sec))
               ops/normalize)
      :cljs (-> (js/Date.)
                .getTimezoneOffset
                -
-               (->> (hash-map :min))
+               (->> (hash-map ::ci/min))
                ops/normalize)))
 
 (defn local []
   (let [now (#?(:clj  java.time.LocalDateTime/now
                 :cljs js/Date.))]
-    {:year  #?(:clj  (-> now .getYear int)
-               :cljs (-> now .getFullYear))
-     :month #?(:clj  (-> now .getMonthValue int)
-               :cljs (-> now .getMonth inc))
-     :day   #?(:clj  (-> now .getDayOfMonth int)
-               :cljs (-> now .getDate))
-     :hour  #?(:clj  (-> now .getHour int)
-               :cljs (-> now .getHours))
-     :min   #?(:clj  (-> now .getMinute int)
-               :cljs (-> now .getMinutes))
-     :sec   #?(:clj  (-> now .getSecond int)
-               :cljs (-> now .getSeconds))
-     :ms    #?(:clj  (-> now .getNano (/ 1000000) int)
-               :cljs (-> now .getMilliseconds))
-     :tz    (:hour (tz-offset))}))
+    #::cd{:year  #?(:clj  (-> now .getYear int)
+                    :cljs (-> now .getFullYear))
+          :month #?(:clj  (-> now .getMonthValue int)
+                    :cljs (-> now .getMonth inc))
+          :day   #?(:clj  (-> now .getDayOfMonth int)
+                    :cljs (-> now .getDate))
+          :hour  #?(:clj  (-> now .getHour int)
+                    :cljs (-> now .getHours))
+          :min   #?(:clj  (-> now .getMinute int)
+                    :cljs (-> now .getMinutes))
+          :sec   #?(:clj  (-> now .getSecond int)
+                    :cljs (-> now .getSeconds))
+          :ms    #?(:clj  (-> now .getNano (/ 1000000) int)
+                    :cljs (-> now .getMilliseconds))
+          :tz    (::ci/hour (tz-offset))}))
 
 (defn utc []
   (let [now #?(:clj  (java.time.LocalDateTime/ofInstant
                       (java.time.Instant/now)
                       java.time.ZoneOffset/UTC)
                :cljs (js/Date.))]
-    {:year  #?(:clj  (-> now .getYear int)
-               :cljs (-> now .getUTCFullYear))
-     :month #?(:clj  (-> now .getMonthValue int)
-               :cljs (-> now .getUTCMonth inc))
-     :day   #?(:clj  (-> now .getDayOfMonth int)
-               :cljs (-> now .getUTCDate))
-     :hour  #?(:clj  (-> now .getHour int)
-               :cljs (-> now .getUTCHours))
-     :min   #?(:clj  (-> now .getMinute int)
-               :cljs (-> now .getUTCMinutes))
-     :sec   #?(:clj  (-> now .getSecond int)
-               :cljs (-> now .getUTCSeconds))
-     :ms    #?(:clj  (-> now .getNano (/ 1000000) int)
-               :cljs (-> now .getUTCMilliseconds))
-     :tz    0}))
+    #::cd{:year  #?(:clj  (-> now .getYear int)
+                    :cljs (-> now .getUTCFullYear))
+          :month #?(:clj  (-> now .getMonthValue int)
+                    :cljs (-> now .getUTCMonth inc))
+          :day   #?(:clj  (-> now .getDayOfMonth int)
+                    :cljs (-> now .getUTCDate))
+          :hour  #?(:clj  (-> now .getHour int)
+                    :cljs (-> now .getUTCHours))
+          :min   #?(:clj  (-> now .getMinute int)
+                    :cljs (-> now .getUTCMinutes))
+          :sec   #?(:clj  (-> now .getSecond int)
+                    :cljs (-> now .getUTCSeconds))
+          :ms    #?(:clj  (-> now .getNano (/ 1000000) int)
+                    :cljs (-> now .getUTCMilliseconds))
+          :tz    0}))
 
 (defn today []
-  (select-keys (local) [:year :month :day :tz]))
+  (select-keys (local) [::cd/year ::cd/month ::cd/day ::cd/tz]))
 
 (defn utc-today []
-  (select-keys (utc) [:year :month :day :tz]))
+  (select-keys (utc) [::cd/year ::cd/month ::cd/day ::cd/tz]))

--- a/src/chrono/ops.cljc
+++ b/src/chrono/ops.cljc
@@ -41,7 +41,7 @@
     [y m d]
     (cond
       (> d 0)
-      (let [num-days (u/days-in-month {:year y, :month m})
+      (let [num-days (u/days-in-month #::cd{:year y, :month m})
             dd (- d num-days)]
         (if (<= d num-days)
           [y m d]
@@ -51,8 +51,8 @@
 
       (<= d 0)
       (let [[num-days ny nm] (if (= m 1)
-                               [(u/days-in-month {:year (dec y), :month 12}) (dec y) 12]
-                               [(u/days-in-month {:year y, :month (dec m)}) y (dec m)])
+                               [(u/days-in-month #::cd{:year (dec y), :month 12}) (dec y) 12]
+                               [(u/days-in-month #::cd{:year y, :month (dec m)}) y (dec m)])
             dd (+ num-days d)]
         (if (< 0 dd)
           [ny nm dd]

--- a/src/chrono/ops.cljc
+++ b/src/chrono/ops.cljc
@@ -82,7 +82,7 @@
 (defmethod normalize-rule ::ci/min   [_ t] (normalize-ci-mi t))
 (defmethod normalize-rule ::ci/hour  [_ t] (normalize-ci-h t))
 
-(def datetime-unit-defaults [[::cd/year 0]
+(def datetime-unit-defaults [[::cd/year 1]
                              [::cd/month 1]
                              [::cd/day 1]
                              [::cd/hour 0]

--- a/src/chrono/ops.cljc
+++ b/src/chrono/ops.cljc
@@ -197,7 +197,7 @@
 (def to-normalized-utc (comp normalize #(to-tz % 0)))
 
 (defn- after? [t t']
-  (loop [[[p s] & ps] datetime-unit-defaults]
+  (loop [[[p s] & ps] unit-defaults]
     (let [t->tp #(get % p s)
           tp (t->tp t)
           tp' (t->tp t')]

--- a/src/chrono/ops.cljc
+++ b/src/chrono/ops.cljc
@@ -58,10 +58,13 @@
           [ny nm dd]
           (days-and-months ny nm dd))))))
 
-(defn normalize-cd-d  [x]
-  (if (and (:year x) (:month x) (:day x))
-    (let [[y m d] (days-and-months (:year x) (:month x) (:day x))]
-      (assoc x :year y :month m :day d))
+(defn normalize-cd-d [{::cd/keys [year month day] :as x}]
+  (if (and year month day)
+    (let [[y m d] (days-and-months year month day)]
+      (assoc x
+             ::cd/year y
+             ::cd/month m
+             ::cd/day d))
     x))
 
 (defmulti normalize-rule (fn [unit _] unit))

--- a/src/chrono/ops.cljc
+++ b/src/chrono/ops.cljc
@@ -129,7 +129,7 @@
              {}
              m))
 
-(defn init-plus [a b]
+(defn- init-plus [a b]
   (let [{a-ch :chrono.datetime a-ci :chrono.interval} (group-keys a)
         {b-ch :chrono.datetime b-ci :chrono.interval} (group-keys b)
         tz (or (:tz a-ch) (:tz b-ch))
@@ -160,7 +160,7 @@
    x
    [:year :month :day :hour :min :sec :ms]))
 
-(defn init-minus [a b]
+(defn- init-minus [a b]
   (let [{a-ch :chrono.datetime a-ci :chrono.interval} (group-keys a)
         {b-ch :chrono.datetime b-ci :chrono.interval} (group-keys b)
         tz (:tz a-ch)

--- a/src/chrono/ops.cljc
+++ b/src/chrono/ops.cljc
@@ -123,19 +123,13 @@
 
 (def ^:private default-time {:year 0 :month 1 :day 1 :hour 0 :min 0 :sec 0 :ms 0})
 
-(defn- init-plus [{:keys [tz] :as r} i]
-  (let [i-r-tz (to-tz i tz)]
-    (into (if tz {:tz tz} {})
-          (map (fn [k] {k (+ (get r k 0) (get i-r-tz k 0))}))
-          (disj (set (concat (keys r) (keys i-r-tz))) :tz))))
-
 (defn- append-prefix-to-keys [m prefix]
   (reduce-kv (fn [r k v]
                (assoc r (keyword (name prefix) (name k)) v))
              {}
              m))
 
-(defn init-plus2 [a b]
+(defn init-plus [a b]
   (let [{a-ch :chrono.datetime a-ci :chrono.interval} (group-keys a)
         {b-ch :chrono.datetime b-ci :chrono.interval} (group-keys b)
         tz (or (:tz a-ch) (:tz b-ch))
@@ -155,7 +149,7 @@
 (defn plus
   ([]           default-time)
   ([x]          x)
-  ([x y]        (normalize (init-plus2 x y)))
+  ([x y]        (normalize (init-plus x y)))
   ([x y & more] (reduce plus (plus x y) more)))
 
 (defn invert [x]

--- a/src/chrono/ops.cljc
+++ b/src/chrono/ops.cljc
@@ -261,15 +261,6 @@
 
 (defmulti day-saving "[tz y]" (fn [tz _] tz))
 
-(defmethod day-saving
-  :ny
-  [_ y]
-  (assert (> y 2006) "Not impl.")
-  {:offset 5
-   :ds -1
-   :in #::cd{:year y :month 3 :day (u/more-or-eq y 3 0 8) :hour 2 :min 0}
-   :out #::cd{:year y :month 11 :day (u/more-or-eq y 11 0 1) :hour 2 :min 0}})
-
 (defn *day-saving-with-utc [tz y]
   (let [ds (day-saving tz y)]
     (assoc ds

--- a/src/chrono/tz.cljc
+++ b/src/chrono/tz.cljc
@@ -1,5 +1,6 @@
 (ns chrono.tz
-  (:require [chrono.ops :as ops]
+  (:require [chrono.datetime :as cd]
+            [chrono.ops :as ops]
             [chrono.util :as util]))
 
 
@@ -27,8 +28,8 @@
   (assert (> y 2006) "Not impl.")
   {:offset 5
    :ds -1
-   :in {:year y :month 3 :day (util/more-or-eq y 3 0 8) :hour 2 :min 0}
-   :out {:year y :month 11 :day (util/more-or-eq y 11 0 1) :hour 2 :min 0}})
+   :in #::cd{:year y :month 3 :day (util/more-or-eq y 3 0 8) :hour 2 :min 0}
+   :out #::cd{:year y :month 11 :day (util/more-or-eq y 11 0 1) :hour 2 :min 0}})
 
 ;; https://alcor.concordia.ca/~gpkatch/gdate-algorithm.html
 ;; https://alcor.concordia.ca/~gpkatch/gdate-method.html

--- a/src/chrono/util.cljc
+++ b/src/chrono/util.cljc
@@ -3,6 +3,16 @@
             [chrono.datetime :as cd]
             [chrono.interval :as ci]))
 
+(defn group-keys [m]
+  (reduce-kv (fn [result k v]
+               (let [key-namespace (-> k namespace keyword)
+                     normalized-key (-> k name keyword)]
+                 (assoc-in result
+                           [key-namespace normalized-key]
+                           v)))
+             {}
+             m))
+             
 (defmulti locale (fn[x] x))
 
 (def locale-en

--- a/src/chrono/util.cljc
+++ b/src/chrono/util.cljc
@@ -1,10 +1,11 @@
 (ns chrono.util
-  (:require [clojure.string :as str]))
+  (:require [clojure.string :as str]
+            [chrono.datetime :as cd]))
 
 (defmulti locale (fn[x] x))
 
 (def locale-en
-  {:month
+  {::cd/month
    {1  {:name "January" :short "Jan" :regex "(?i)jan\\S*"}
     2  {:name "February" :short "Feb" :regex "(?i)feb\\S*"}
     3  {:name "March" :short "Mar" :regex "(?i)mar\\S*"}
@@ -22,27 +23,28 @@
 (defmethod locale :default [_] locale-en)
 
 (def parse-patterns
-  {:year  "(?:\\d\\d\\d\\d|\\d\\d\\d|\\d\\d|\\d)"
-   :month "(?:1[0-2]|0[1-9]|[1-9]|\\p{L}+\\.?)"
-   :day   "(?:3[0-1]|[1-2]\\d|0[1-9]|[1-9])"
-   :hour  "(?:2[0-3]|[0-1]\\d|\\d)"
-   :min   "(?:[0-5]\\d|\\d)"
-   :sec   "(?:[0-5]\\d|\\d)"
-   :ms    "(?:\\d\\d\\d|\\d\\d|\\d)"})
+  #::cd{:year  "(?:\\d\\d\\d\\d|\\d\\d\\d|\\d\\d|\\d)"
+        :month "(?:1[0-2]|0[1-9]|[1-9]|\\p{L}+\\.?)"
+        :day   "(?:3[0-1]|[1-2]\\d|0[1-9]|[1-9])"
+        :hour  "(?:2[0-3]|[0-1]\\d|\\d)"
+        :min   "(?:[0-5]\\d|\\d)"
+        :sec   "(?:[0-5]\\d|\\d)"
+        :ms    "(?:\\d\\d\\d|\\d\\d|\\d)"})
 
 (def format-patterns
-  {:year  4
-   :month 2
-   :day   2
-   :hour  2
-   :min   2
-   :sec   2
-   :ms    3})
+  #::cd{:year  4
+        :month 2
+        :day   2
+        :hour  2
+        :min   2
+        :sec   2
+        :ms    3})
 
 (defn sanitize [s]
   (str/replace s #"[-.\+*?\[^\]$(){}=!<>|:\\]" #(str \\ %)))
 
-(def iso-fmt [:year "-" :month "-" :day "T" :hour ":" :min ":" :sec "." :ms])
+(def iso-fmt [::cd/year "-" ::cd/month "-" ::cd/day "T"
+              ::cd/hour ":" ::cd/min ":" ::cd/sec "." ::cd/ms])
 
 (defn parse-name [name unit lang]
   (-> (locale lang)
@@ -65,7 +67,7 @@
        (or (pos? (rem y 100))
            (zero? (rem y 400)))))
 
-(defn days-in-month [{m :month, y :year}]
+(defn days-in-month [{m ::cd/month, y ::cd/year}]
   (cond
     (contains? #{4 6 9 11} m) 30
     (and (leap-year? y) (= 2 m)) 29
@@ -131,10 +133,10 @@
 (def pad-zero (partial pad-str \0))
 
 (defn seconds [d]
-  (+ (* (dec (:day d)) 60 60 24)
-     (* (:hour d) 60 60)
-     (* (:min d) 60)
-     (:sec d)))
+  (+ (* (dec (::cd/day d)) 60 60 24)
+     (* (::cd/hour d) 60 60)
+     (* (::cd/min d) 60)
+     (::cd/sec d)))
 
 (defn day-of-week
   "m 1-12; y > 1752"

--- a/src/chrono/util.cljc
+++ b/src/chrono/util.cljc
@@ -1,6 +1,7 @@
 (ns chrono.util
   (:require [clojure.string :as str]
-            [chrono.datetime :as cd]))
+            [chrono.datetime :as cd]
+            [chrono.interval :as ci]))
 
 (defmulti locale (fn[x] x))
 
@@ -23,13 +24,18 @@
 (defmethod locale :default [_] locale-en)
 
 (def parse-patterns
-  #::cd{:year  "(?:\\d\\d\\d\\d|\\d\\d\\d|\\d\\d|\\d)"
-        :month "(?:1[0-2]|0[1-9]|[1-9]|\\p{L}+\\.?)"
-        :day   "(?:3[0-1]|[1-2]\\d|0[1-9]|[1-9])"
-        :hour  "(?:2[0-3]|[0-1]\\d|\\d)"
-        :min   "(?:[0-5]\\d|\\d)"
-        :sec   "(?:[0-5]\\d|\\d)"
-        :ms    "(?:\\d\\d\\d|\\d\\d|\\d)"})
+  {::cd/year  "(?:\\d\\d\\d\\d|\\d\\d\\d|\\d\\d|\\d)"
+   ::cd/month "(?:1[0-2]|0[1-9]|[1-9]|\\p{L}+\\.?)"
+   ::cd/day   "(?:3[0-1]|[1-2]\\d|0[1-9]|[1-9])"
+   ::cd/hour  "(?:2[0-3]|[0-1]\\d|\\d)"
+   ::cd/min   "(?:[0-5]\\d|\\d)"
+   ::cd/sec   "(?:[0-5]\\d|\\d)"
+   ::cd/ms    "(?:\\d\\d\\d|\\d\\d|\\d)"
+   ::ci/day   "(?:[0-9]+)"
+   ::ci/hour  "(?:2[0-3]|[0-1]\\d|\\d)"
+   ::ci/min   "(?:[0-5]\\d|\\d)"
+   ::ci/sec   "(?:[0-5]\\d|\\d)"
+   ::ci/ms    "(?:\\d\\d\\d|\\d\\d|\\d)"})
 
 (def format-patterns
   #::cd{:year  4

--- a/test/chrono/calendar_test.clj
+++ b/test/chrono/calendar_test.clj
@@ -1,16 +1,41 @@
 (ns chrono.calendar-test
   (:require [chrono.calendar :as sut]
+            [chrono.datetime :as cd]
             [clojure.test :refer [deftest]]
             [matcho.core :as matcho]))
 
 (deftest calendar-test
-
   (matcho/match
    (sut/for-month 2018 3)
-   {:year 2018 :month 3
-    :cal [[{:month 2 :day 25} {:month 2 :day 26} {:month 2 :day 27} {:month 2 :day 28} {:month 3 :day 1} {:month 3 :day 2} {:month 3 :day 3}]
-          [{:month 3 :day 4} {:month 3 :day 5} {:month 3 :day 6} {:month 3 :day 7} {:month 3 :day 8} {:month 3 :day 9} {:month 3 :day 10}]
-          [{:month 3 :day 11} {:month 3 :day 12} {:month 3 :day 13} {:month 3 :day 14} {:month 3 :day 15} {:month 3 :day 16} {:month 3 :day 17}]
+   {::cd/year 2018
+    ::cd/month 3
+    :cal [[#::cd{:month 2 :day 25}
+           #::cd{:month 2 :day 26}
+           #::cd{:month 2 :day 27}
+           #::cd{:month 2 :day 28}
+           #::cd{:month 3 :day 1}
+           #::cd{:month 3 :day 2}
+           #::cd{:month 3 :day 3}]
+          [#::cd{:month 3 :day 4}
+           #::cd{:month 3 :day 5}
+           #::cd{:month 3 :day 6}
+           #::cd{:month 3 :day 7}
+           #::cd{:month 3 :day 8}
+           #::cd{:month 3 :day 9}
+           #::cd{:month 3 :day 10}]
+          [#::cd{:month 3 :day 11}
+           #::cd{:month 3 :day 12}
+           #::cd{:month 3 :day 13}
+           #::cd{:month 3 :day 14}
+           #::cd{:month 3 :day 15}
+           #::cd{:month 3 :day 16}
+           #::cd{:month 3 :day 17}]
           []
           []
-          [{:month 4 :day 1} {:month 4 :day 2} {:month 4 :day 3} {:month 4 :day 4} {:month 4 :day 5} {:month 4 :day 6} {:month 4 :day 7}]]}))
+          [#::cd{:month 4 :day 1}
+           #::cd{:month 4 :day 2}
+           #::cd{:month 4 :day 3}
+           #::cd{:month 4 :day 4}
+           #::cd{:month 4 :day 5}
+           #::cd{:month 4 :day 6}
+           #::cd{:month 4 :day 7}]]}))

--- a/test/chrono/crono_test.clj
+++ b/test/chrono/crono_test.clj
@@ -1,113 +1,107 @@
 (ns chrono.crono-test
   (:require [chrono.crono :as sut]
+            [chrono.datetime :as cd]
+            [chrono.interval :as ci]
             [clojure.test :refer :all]))
 
 (deftest crono-test
+  (is (= #::cd{:year 2020 :month 1 :day 1 :hour 12}
+         (sut/next-time #::cd{:year 2020 :month 1 :day 1 :hour 11}
+                        {:every ::ci/day :at {::cd/hour 12}})))
 
+  (is (= #::cd{:year 2020 :month 1 :day 2 :hour 12}
+         (sut/next-time #::cd{:year 2020 :month 1 :day 1 :hour 12 :min 10}
+                        {:every ::ci/day :at {::cd/hour 12}})))
 
-  (is (= {:year 2020 :month 1 :day 1 :hour 12}
-         (sut/next-time {:year 2020 :month 1 :day 1 :hour 11}
-                        {:every :day :at {:hour 12}})))
+  (is (= #::cd{:year 2020 :month 1 :day 1 :hour 14}
+         (sut/next-time #::cd{:year 2020 :month 1 :day 1 :hour 13}
+                        {:every ::ci/day :at [{::cd/hour 12}
+                                              {::cd/hour 14}]})))
 
-  (is (= {:year 2020 :month 1 :day 2 :hour 12}
-         (sut/next-time {:year 2020 :month 1 :day 1 :hour 12 :min 10}
-                        {:every :day :at {:hour 12}})))
+  (is (= #::cd{:year 2020 :month 1 :day 1 :hour 10 :min 30}
+         (sut/next-time #::cd{:year 2020 :month 1 :day 1 :hour 10 :min 13}
+                        {:every ::ci/hour :at [{::cd/min 0} {::cd/min 30}]})))
 
-  (is (= {:year 2020 :month 1 :day 1 :hour 14}
-         (sut/next-time {:year 2020 :month 1 :day 1 :hour 13}
-                        {:every :day :at [{:hour 12}
-                                          {:hour 14}]})))
+  (is (= #::cd{:year 2020 :month 1 :day 1 :hour 12}
+         (sut/next-time #::cd{:year 2020 :month 1 :day 1 :hour 11 :min 43}
+                        {:every ::ci/hour :at [{::cd/min 0} {::cd/min 30}]})))
 
-  (is (= {:year 2020 :month 1 :day 1 :hour 10 :min 30}
-         (sut/next-time {:year 2020 :month 1 :day 1 :hour 10 :min 13}
-                        {:every :hour :at [{:min 0} {:min 30}]})))
+  (is (= #::cd{:year 2020 :month 1 :day 1 :hour 12 :min 10}
+         (sut/next-time #::cd{:year 2020 :month 1 :day 1 :hour 12 :min 7}
+                        {:every ::ci/hour :at [{::cd/min 0}
+                                               {::cd/min 5}
+                                               {::cd/min 10}
+                                               {::cd/min 15}
+                                               {::cd/min 20}
+                                               {::cd/min 25}
+                                               {::cd/min 30}
+                                               {::cd/min 35}
+                                               {::cd/min 40}
+                                               {::cd/min 45}
+                                               {::cd/min 50}
+                                               {::cd/min 55}]})))
 
-  (is (= {:year 2020 :month 1 :day 1 :hour 12}
-         (sut/next-time {:year 2020 :month 1 :day 1 :hour 11 :min 43}
-                        {:every :hour :at [{:min 0} {:min 30}]})))
+  (is (= #::cd{:year 2020 :month 1 :day 1 :hour 11}
+         (sut/next-time #::cd{:year 2020 :month 1 :day 1 :hour 10 :min 55}
+                        {:every ::ci/hour :at [{::cd/min 0}
+                                               {::cd/min 5}
+                                               {::cd/min 10}
+                                               {::cd/min 15}
+                                               {::cd/min 20}
+                                               {::cd/min 25}
+                                               {::cd/min 30}
+                                               {::cd/min 35}
+                                               {::cd/min 40}
+                                               {::cd/min 45}
+                                               {::cd/min 50}
+                                               {::cd/min 55}]})))
 
-  (is (= {:year 2020 :month 1 :day 1 :hour 12 :min 10}
-         (sut/next-time {:year 2020 :month 1 :day 1 :hour 12 :min 7}
-                        {:every :hour :at [{:min 0}
-                                           {:min 5}
-                                           {:min 10}
-                                           {:min 15}
-                                           {:min 20}
-                                           {:min 25}
-                                           {:min 30}
-                                           {:min 35}
-                                           {:min 40}
-                                           {:min 45}
-                                           {:min 50}
-                                           {:min 55}]})))
+  (is (= #::cd{:year 2020 :month 1 :day 1 :hour 12}
+         (sut/next-time #::cd{:year 2020 :month 1 :day 1 :hour 11 :min 9 :sec 10}
+                        {:every ::ci/hour})))
 
-  (is (= {:year 2020 :month 1 :day 1 :hour 11}
-         (sut/next-time {:year 2020 :month 1 :day 1 :hour 10 :min 55}
-                        {:every :hour :at [{:min 0}
-                                           {:min 5}
-                                           {:min 10}
-                                           {:min 15}
-                                           {:min 20}
-                                           {:min 25}
-                                           {:min 30}
-                                           {:min 35}
-                                           {:min 40}
-                                           {:min 45}
-                                           {:min 50}
-                                           {:min 55}]})))
+  (is (= #::cd{:year 2020 :month 1 :day 1 :hour 11 :min 10}
+         (sut/next-time #::cd{:year 2020 :month 1 :day 1 :hour 11 :min 9 :sec 10}
+                        {:every ::ci/min})))
 
-  (is (= {:year 2020 :month 1 :day 1 :hour 12}
-         (sut/next-time {:year 2020 :month 1 :day 1 :hour 11 :min 9 :sec 10}
-                        {:every :hour})))
+  (is (= #::cd{:year 2020 :month 1 :day 1 :hour 11 :min 10}
+         (sut/next-time #::cd{:year 2020 :month 1 :day 1 :hour 11 :min 9 :sec 10}
+                        {:every ::ci/min :at {::cd/sec 0}})))
 
-  (is (= {:year 2020 :month 1 :day 1 :hour 11 :min 10}
-         (sut/next-time {:year 2020 :month 1 :day 1 :hour 11 :min 9 :sec 10}
-                        {:every :min})))
-
-  (is (= {:year 2020 :month 1 :day 1 :hour 11 :min 10}
-         (sut/next-time {:year 2020 :month 1 :day 1 :hour 11 :min 9 :sec 10}
-                        {:every :min :at {:sec 0}})))
-
-  (is (= {:year 2020 :month 1 :day 1 :hour 11 :min 10 :sec 10}
-         (sut/next-time {:year 2020 :month 1 :day 1 :hour 11 :min 9 :sec 10}
-                        {:every :min :at {:sec 10}})))
+  (is (= #::cd{:year 2020 :month 1 :day 1 :hour 11 :min 10 :sec 10}
+         (sut/next-time #::cd{:year 2020 :month 1 :day 1 :hour 11 :min 9 :sec 10}
+                        {:every ::ci/min :at {::cd/sec 10}})))
 
 
   (is (= true
-         (sut/now? {:year 2020 :month 1 :day 1 :hour 12 :min 1}
-                   {:every :day
-                    :at {:hour 12}
-                    :until {:hour 12 :min 30}})))
+         (sut/now? #::cd{:year 2020 :month 1 :day 1 :hour 12 :min 1}
+                   {:every ::ci/day
+                    :at {::cd/hour 12}
+                    :until {::cd/hour 12 ::cd/min 30}})))
 
   (is (= false
-         (sut/now? {:year 2020 :month 1 :day 1 :hour 12 :min 31}
-                   {:every :day
-                    :at {:hour 12}
-                    :until {:hour 12 :min 30}})))
+         (sut/now? #::cd{:year 2020 :month 1 :day 1 :hour 12 :min 31}
+                   {:every ::ci/day
+                    :at {::cd/hour 12}
+                    :until {::cd/hour 12 ::cd/min 30}})))
 
   (is (= true
-         (sut/now? {:year 2020 :month 1 :day 1 :hour 12 :min 31}
-                   {:every :day
-                    :at {:hour 12}})))
+         (sut/now? #::cd{:year 2020 :month 1 :day 1 :hour 12 :min 31}
+                   {:every ::ci/day
+                    :at {::cd/hour 12}})))
 
-  (is (= {:year 2020 :month 1 :day 1 :hour 12}
-         (sut/next-time {:year 2020 :month 1 :day 1 :hour 11}
-                        {:every "day" :at {:hour 12}})))
+  (is (= #::cd{:year 2020 :month 5 :day 18 :hour 10}
+         (sut/next-time #::cd{:year 2020 :month 5 :day 17 :hour 9}
+                        {:every "monday" :at {::cd/hour 10}})))
 
-  (is (= {:year 2020 :month 5 :day 18 :hour 10}
-         (sut/next-time {:year 2020 :month 5 :day 17 :hour 9}
-                        {:every "monday" :at {:hour 10}})))
+  (is (= #::cd{:year 2020 :month 5 :day 18 :hour 10}
+         (sut/next-time #::cd{:year 2020 :month 5 :day 18 :hour 9}
+                        {:every "monday" :at {::cd/hour 10}})))
 
-  (is (= {:year 2020 :month 5 :day 18 :hour 10}
-         (sut/next-time {:year 2020 :month 5 :day 18 :hour 9}
-                        {:every "monday" :at {:hour 10}})))
+  (is (= #::cd{:year 2020 :month 5 :day 26 :hour 10}
+         (sut/next-time #::cd{:year 2020 :month 5 :day 19 :hour 11}
+                        {:every "tuesday" :at {::cd/hour 10}})))
 
-  (is (= {:year 2020 :month 5 :day 26 :hour 10}
-         (sut/next-time {:year 2020 :month 5 :day 19 :hour 11}
-                        {:every "tuesday" :at {:hour 10}})))
-
-  (is (= {:year 2020 :month 5 :day 19 :hour 10}
-         (sut/next-time {:year 2020 :month 5 :day 18 :hour 11}
-                        {:every "tuesday" :at {:hour 10}})))
-
-  )
+  (is (= #::cd{:year 2020 :month 5 :day 19 :hour 10}
+         (sut/next-time #::cd{:year 2020 :month 5 :day 18 :hour 11}
+                        {:every "tuesday" :at {::cd/hour 10}}))))

--- a/test/chrono/io_test.clj
+++ b/test/chrono/io_test.clj
@@ -80,7 +80,13 @@
         (matcho/match (sut/parse "month 19" ^:ru[::cd/month \space ::cd/year]) nil))
 
       (testing "invalid locale name"
-        (matcho/match (sut/parse "январь 19" ^:en[::cd/month \space ::cd/year]) nil))))
+        (matcho/match (sut/parse "январь 19" ^:en[::cd/month \space ::cd/year]) nil)))
+
+    (testing "intervals"
+      (is (= #::ci{:hour 20 :min 30}
+             (sut/parse "20:30" [::ci/hour \: ::ci/min])))
+      (is (= #::ci{:day 50}
+             (sut/parse "50d" [::ci/day \d])))))
 
   (testing "format"
     (is (= "12/01/2010"
@@ -106,7 +112,14 @@
       (is (= "5.000001234" (sut/format {::cd/sec 5 :ns 1234}
                                        [[::cd/sec 1] \. ::cd/ms [:ns 6]])))
       (is (= "5.000123456" (sut/format {::cd/sec 5 :ns 123456}
-                                       [[::cd/sec 1] \. ::cd/ms :ns])))))
+                                       [[::cd/sec 1] \. ::cd/ms :ns]))))
+    (testing "intervals"
+      (is (= "20 hours 3 minutes"
+             (sut/format #::ci{:hour 20 :min 3}
+                         [::ci/hour " hours " ::ci/min " minutes"])))
+      (is (= "50 days"
+             (sut/format #::ci{:day 50}
+                         [::ci/day " days"])))))
 
   (testing "roundtrip"
     (let [t #::cd{:year 2019, :month 9, :day 16, :hour 23, :min 0, :sec 38, :ms 911}]

--- a/test/chrono/io_test.clj
+++ b/test/chrono/io_test.clj
@@ -2,168 +2,190 @@
   (:require [clojure.test :refer :all]
             [matcho.core :as matcho]
             [chrono.io :as sut]
+            [chrono.datetime :as cd]
+            [chrono.interval :as ci]
             [chrono.locale-ru]
             [clojure.string :as str]))
 
 (deftest parse-format-test
   (testing "nil safe"
     (matcho/match (sut/parse nil) nil)
-    (matcho/match (sut/format nil [:day]) "00"))
+    (matcho/match (sut/format nil [::cd/day]) "00"))
 
   (testing "parse"
-
     (testing "numeral representation of month"
       (matcho/match
        (sut/parse "2011-01-01")
-       {:year 2011 :month 1 :day 1})
+       #::cd{:year 2011 :month 1 :day 1})
 
       (matcho/match
        (sut/parse "2011-01-01T12:00")
-       {:year 2011 :month 1 :day 1 :hour 12 :min 0})
+       #::cd{:year 2011 :month 1 :day 1 :hour 12 :min 0})
 
       (matcho/match
        (sut/parse "2011-01-01T12:00:00")
-       {:year 2011 :month 1 :day 1 :hour 12 :min 0 :sec 0})
+       #::cd{:year 2011 :month 1 :day 1 :hour 12 :min 0 :sec 0})
 
       (matcho/match
        (sut/parse "2011-01-01T12:04:05.100")
-       {:year 2011 :month 1 :day 1 :hour 12 :min 4 :sec 5 :ms 100})
+       #::cd{:year 2011 :month 1 :day 1 :hour 12 :min 4 :sec 5 :ms 100})
 
       (matcho/match
-       (sut/parse "16.09.2019 23:59:01" [:day \. :month \. :year \space :hour \: :min \: :sec])
-       {:day 16, :month 9, :year 2019, :hour 23, :min 59, :sec 1}))
+       (sut/parse "16.09.2019 23:59:01" [::cd/day \. ::cd/month \. ::cd/year \space
+                                         ::cd/hour \: ::cd/min \: ::cd/sec])
+       #::cd{:day 16, :month 9, :year 2019, :hour 23, :min 59, :sec 1}))
+
     (testing "literal representation of month"
       (testing "default lang"
         (matcho/match
          (sut/parse "16 Jan 2019 23:59:01"
-                    [:day \space :month \space :year \space :hour \: :min \: :sec])
-         {:day 16, :month 1, :year 2019, :hour 23, :min 59, :sec 1})
+                    [::cd/day \space ::cd/month \space ::cd/year \space
+                     ::cd/hour \: ::cd/min \: ::cd/sec])
+         #::cd{:day 16, :month 1, :year 2019, :hour 23, :min 59, :sec 1})
 
         (matcho/match
          (sut/parse "31 December 2023 13:30:19"
-                    [:day \space :month \space :year \space :hour \: :min \: :sec])
-         {:day 31, :month 12, :year 2023, :hour 13, :min 30, :sec 19})
+                    [::cd/day \space ::cd/month \space ::cd/year \space
+                     ::cd/hour \: ::cd/min \: ::cd/sec])
+         #::cd{:day 31, :month 12, :year 2023, :hour 13, :min 30, :sec 19})
         (matcho/match
          (sut/parse "31 march 2023 13:30:19"
-                    [:day \space :month \space :year \space :hour \: :min \: :sec])
-         {:day 31, :month 3, :year 2023, :hour 13, :min 30, :sec 19})
+                    [::cd/day \space ::cd/month \space ::cd/year \space
+                     ::cd/hour \: ::cd/min \: ::cd/sec])
+         #::cd{:day 31, :month 3, :year 2023, :hour 13, :min 30, :sec 19})
         (matcho/match
          (sut/parse "28 FEB 2023 13:30:19"
-                    [:day \space :month \space :year \space :hour \: :min \: :sec])
-         {:day 28, :month 2, :year 2023, :hour 13, :min 30, :sec 19})
+                    [::cd/day \space ::cd/month \space ::cd/year \space
+                     ::cd/hour \: ::cd/min \: ::cd/sec])
+         #::cd{:day 28, :month 2, :year 2023, :hour 13, :min 30, :sec 19})
         (matcho/match
-         (sut/parse "jun. 28 9999" [:month \space :day \space :year])
-         {:day 28, :month 6, :year 9999}))
+         (sut/parse "jun. 28 9999" [::cd/month \space ::cd/day \space ::cd/year])
+         #::cd{:day 28, :month 6, :year 9999}))
       (testing "en"
         (matcho/match
-         (sut/parse "sep. 19 2023" ^:en[:month \space :day \space :year])
-         {:day 19, :month 9, :year 2023}))
+         (sut/parse "sep. 19 2023" ^:en[::cd/month \space ::cd/day \space ::cd/year])
+         #::cd{:day 19, :month 9, :year 2023}))
       (testing "ru"
         (matcho/match
-         (sut/parse "19 января" ^:ru[:day \space :month])
-         {:day 19 :month 1})
+         (sut/parse "19 января" ^:ru[::cd/day \space ::cd/month])
+         #::cd{:day 19 :month 1})
         (matcho/match
-         (sut/parse "февраль 19" ^:ru[:month \space :year])
-         {:year 19 :month 2})
+         (sut/parse "февраль 19" ^:ru[::cd/month \space ::cd/year])
+         #::cd{:year 19 :month 2})
         (matcho/match
-         (sut/parse "окт 9:36" ^:ru[:month \space :hour \: :min])
-         {:month 10 :hour 9 :min 36}))
+         (sut/parse "окт 9:36" ^:ru[::cd/month \space ::cd/hour \: ::cd/min])
+         #::cd{:month 10 :hour 9 :min 36}))
       (testing "invalid month name"
-        (matcho/match (sut/parse "19 month" ^:ru[:year \space :month]) {:year 19})
-        (matcho/match (sut/parse "month 19" ^:ru[:month \space :year]) nil))
+        (matcho/match (sut/parse "19 month" ^:ru[::cd/year \space ::cd/month]) {::cd/year 19})
+        (matcho/match (sut/parse "month 19" ^:ru[::cd/month \space ::cd/year]) nil))
 
       (testing "invalid locale name"
-        (matcho/match (sut/parse "январь 19" ^:en[:month \space :year]) nil))))
+        (matcho/match (sut/parse "январь 19" ^:en[::cd/month \space ::cd/year]) nil))))
 
   (testing "format"
-    (is (= "12/01/2010" (sut/format {:year 2010 :month 12 :day 1} [:month "/" :day "/" :year])))
+    (is (= "12/01/2010"
+           (sut/format #::cd{:year 2010 :month 12 :day 1}
+                       [::cd/month "/" ::cd/day "/" ::cd/year])))
     (testing "month-name"
       (is (= "Октябрь 2009"
-             (sut/format {:year 2009 :month 10} ^:ru [:month \space :year])))
+             (sut/format #::cd{:year 2009 :month 10}
+                         ^:ru[::cd/month \space ::cd/year])))
       (is (= "Sep. 1"
-             (sut/format {:month 9 :day 1} ^:en [[:month :short] \. \space [:day 1]])))
+             (sut/format #::cd{:month 9 :day 1}
+                         ^:en[[::cd/month :short] \. \space [::cd/day 1]])))
       (is (= "1:month:entest"
-             (sut/format {:month 1}
-                         ^:en[[:month (fn [v [kw _ s] lc] (str/join [v kw lc s])) "test"]])))
+             (sut/format {::cd/month 1}
+                         ^:en[[::cd/month
+                               (fn [v [kw _ s] lc]
+                                 (str/join [v (-> kw name keyword) lc s]))
+                               "test"]])))
       (is (= "3"
-             (sut/format {:month 9 :day 1} [[:month (fn [& args] (count args))]]))))
+             (sut/format #::cd{:month 9 :day 1}
+                         [[::cd/month (fn [& args] (count args))]]))))
     (testing "custom keys"
-      (is (= "5.000001234" (sut/format {:sec 5 :ns 1234} [[:sec 1] \. :ms [:ns 6]])))
-      (is (= "5.000123456" (sut/format {:sec 5 :ns 123456} [[:sec 1] \. :ms :ns])))))
+      (is (= "5.000001234" (sut/format {::cd/sec 5 :ns 1234}
+                                       [[::cd/sec 1] \. ::cd/ms [:ns 6]])))
+      (is (= "5.000123456" (sut/format {::cd/sec 5 :ns 123456}
+                                       [[::cd/sec 1] \. ::cd/ms :ns])))))
 
   (testing "roundtrip"
-    (let [t {:year 2019, :month 9, :day 16, :hour 23, :min 0, :sec 38, :ms 911}]
+    (let [t #::cd{:year 2019, :month 9, :day 16, :hour 23, :min 0, :sec 38, :ms 911}]
       (matcho/match (sut/parse (sut/format t)) t)))
 
   (testing "format with specified width"
-    (is
-     (=
-      "06.03.20"
-      (sut/format {:year 2020 :month 3 :day 6} [:day \. :month \. [:year 2]])))
-    (is
-     (=
-      "06.03.2020"
-      (sut/format {:year 2020 :month 3 :day 6} [:day \. :month \. :year])))
-    (is
-     (=
-      "2020.03.06"
-      (sut/format {:year 2020 :month 3 :day 6} [:year \. :month \. :day])))
-    (is
-     (=
-      "20.03.06"
-      (sut/format {:year 2020 :month 3 :day 6} [[:year 2] \. :month \. :day]))))
+    (is (= "06.03.20"
+           (sut/format #::cd{:year 2020 :month 3 :day 6}
+                       [::cd/day \. ::cd/month \. [::cd/year 2]])))
+    (is (= "06.03.2020"
+           (sut/format #::cd{:year 2020 :month 3 :day 6}
+                       [::cd/day \. ::cd/month \. ::cd/year])))
+    (is (= "2020.03.06"
+           (sut/format #::cd{:year 2020 :month 3 :day 6}
+                       [::cd/year \. ::cd/month \. ::cd/day])))
+    (is (= "20.03.06"
+           (sut/format #::cd{:year 2020 :month 3 :day 6}
+                       [[::cd/year 2] \. ::cd/month \. ::cd/day]))))
   (testing "parse should return parsed value even if format not strictly cosistent"
     (matcho/match
-     (sut/parse "2011-01-01" [:year "-" :month]) {:year 2011 :month 1})
+     (sut/parse "2011-01-01" [::cd/year "-" ::cd/month])
+     #::cd{:year 2011 :month 1})
 
     (matcho/match
-     (sut/parse "2011-01-01" [:year "-" :month "-" :day "T" :hour]) {:year 2011 :month 1})))
+     (sut/parse "2011-01-01" [::cd/year "-" ::cd/month "-" ::cd/day "T" ::cd/hour])
+     #::cd{:year 2011 :month 1})))
 
 (testing "parsing invalid strings should return only parsed part"
   (matcho/match
-   (sut/parse "2020-12-ab" [:year "-" :month "-" :day]) {:year 2020 :month 12}))
+   (sut/parse "2020-12-ab" [::cd/year "-" ::cd/month "-" ::cd/day])
+   #::cd{:year 2020 :month 12}))
 
 (deftest strict-parse-test
   (testing "strict parse should return value when format exact match"
     (matcho/match
-     (sut/strict-parse "2011-01-01" [:year \- :month \- :day])
-     {:year 2011 :month 1 :day 1})
+     (sut/strict-parse "2011-01-01" [::cd/year \- ::cd/month \- ::cd/day])
+     #::cd{:year 2011 :month 1 :day 1})
 
     (matcho/match
-     (sut/strict-parse "16.09.2019 23:59:01" [:day \. :month \. :year \space :hour \: :min \: :sec])
-     {:day 16, :month 9, :year 2019, :hour 23, :min 59, :sec 1}))
+     (sut/strict-parse "16.09.2019 23:59:01" [::cd/day \. ::cd/month \. ::cd/year \space
+                                              ::cd/hour \: ::cd/min \: ::cd/sec])
+     #::cd{:day 16, :month 9, :year 2019, :hour 23, :min 59, :sec 1}))
 
   (testing "strict parse should return nil when format not strictly consistent"
     (matcho/match
-     (sut/strict-parse "2011-01-01" [:year "-" :month])
+     (sut/strict-parse "2011-01-01" [::cd/year "-" ::cd/month])
      nil)
 
     (matcho/match
-     (sut/strict-parse "2011-01-01" [:year "-" :month "-" :day "T" :hour])
+     (sut/strict-parse "2011-01-01" [::cd/year "-" ::cd/month "-" ::cd/day "T" ::cd/hour])
      nil))
 
   (testing "parsing invalid strings should return nil"
-        (matcho/match
-     (sut/strict-parse "2011-23" [:year "-" :month]) nil)
+    (matcho/match
+     (sut/strict-parse "2011-23" [::cd/year "-" ::cd/month]) nil)
 
     (matcho/match
-     (sut/strict-parse "2011-12" [:month "-" :year]) nil))
+     (sut/strict-parse "2011-12" [::cd/month "-" ::cd/year]) nil))
 
   (testing "strict parsing month names"
     (matcho/match
-     (sut/strict-parse "2011-JUL" [:year "-" :month]) {:year 2011 :month 7})))
+     (sut/strict-parse "2011-JUL" [::cd/year "-" ::cd/month])
+     #::cd{:year 2011 :month 7})))
 
 (deftest format-str-test
   (testing "month names"
-    (is (= "November" (#'sut/format-str 11 [:month] :en)))
-    (is (= "Март" (#'sut/format-str 3 [:month] :ru)))
-    (is (= "Aug" (#'sut/format-str 8 [:month :short] :en)))
-    (is (= "09" (#'sut/format-str 9 [:month :short] nil)))))
+    (is (= "November" (#'sut/format-str 11 [::cd/month] :en)))
+    (is (= "Март" (#'sut/format-str 3 [::cd/month] :ru)))
+    (is (= "Aug" (#'sut/format-str 8 [::cd/month :short] :en)))
+    (is (= "09" (#'sut/format-str 9 [::cd/month :short] nil)))))
 
 (deftest from-epoch-test
-  (is (= {:day 22, :month 4, :year 2020, :sec 40, :min 49, :hour 1} (sut/from-epoch 1587520180)))
-  (is (= {:day 1, :month 1, :year 1970} (sut/from-epoch 0))))
+  (is (= #::cd{:day 22, :month 4, :year 2020, :sec 40, :min 49, :hour 1}
+         (sut/from-epoch 1587520180)))
+  (is (= #::cd{:day 1, :month 1, :year 1970}
+         (sut/from-epoch 0))))
 
 (deftest to-epoch-test
-  (is (= 1587520180 (sut/to-epoch {:day 22, :month 4, :year 2020, :sec 40, :min 49, :hour 1})))
-  (is (= 0 (sut/to-epoch {:day 1, :month 1, :year 1970, :sec 0, :min 0, :hour 0}))))
+  (is (= 1587520180
+         (sut/to-epoch #::cd{:day 22, :month 4, :year 2020, :sec 40, :min 49, :hour 1})))
+  (is (= 0
+         (sut/to-epoch #::cd{:day 1, :month 1, :year 1970, :sec 0, :min 0, :hour 0}))))

--- a/test/chrono/io_test.clj
+++ b/test/chrono/io_test.clj
@@ -123,7 +123,10 @@
 
   (testing "roundtrip"
     (let [t #::cd{:year 2019, :month 9, :day 16, :hour 23, :min 0, :sec 38, :ms 911}]
-      (matcho/match (sut/parse (sut/format t)) t)))
+      (matcho/match (sut/parse (sut/format t)) t))
+    (let [i #::ci{:day 50 :hour 20 :min 30 :sec 5 :ms 123}
+          fmt [::ci/day \space ::ci/hour \space ::ci/min \space ::ci/sec \. ::ci/ms]]
+      (is (= i (-> i (sut/format fmt) (sut/parse fmt))))))
 
   (testing "format with specified width"
     (is (= "06.03.20"

--- a/test/chrono/mask_test.clj
+++ b/test/chrono/mask_test.clj
@@ -1,10 +1,11 @@
 (ns chrono.mask-test
   (:require [chrono.mask :as sut]
             [clojure.test :as t]
-            [chrono.io :as io]))
+            [chrono.io :as io]
+            [chrono.datetime :as cd]))
 
 (t/deftest mask-test
-  (let [cases {[:hour \: :min \: :sec]
+  (let [cases {[::cd/hour \: ::cd/min \: ::cd/sec]
                {"2300"     "23:00:"
                 "23:00"    "23:00:"
                 "230000"   "23:00:00"
@@ -23,7 +24,7 @@
                 "399"      "03:09:09"
                 "999999"   "09:09:09"}
 
-               [:month \- :day]
+               [::cd/month \- ::cd/day]
                {"01-01" "01-01"
                 "0101"  "01-01"
                 "67"    "06-07"
@@ -44,4 +45,4 @@
     (doseq [[fmt facts] cases
             [inp res]   facts]
       (t/testing (str "resolve: " fmt " " inp)
-          (t/is (= res (sut/resolve inp fmt)))))))
+        (t/is (= res (sut/resolve inp fmt)))))))

--- a/test/chrono/ops_test.clj
+++ b/test/chrono/ops_test.clj
@@ -1,8 +1,9 @@
 (ns chrono.ops-test
-  (:require [chrono.ops :as sut]
-            [matcho.core :as matcho]
-            [clojure.test :refer :all]))
-
+  (:require [chrono.core :as ch]
+            [chrono.interval :as ci]
+            [chrono.ops :as sut]
+            [clojure.test :refer :all]
+            [matcho.core :as matcho]))
 
 (deftest days-and-months
   (is (= [2011 4 10] (sut/days-and-months 2011 1 100)))
@@ -20,356 +21,370 @@
 
   (is (= [2012 1 1] (sut/days-and-months 2013 1 -365))))
 
-(deftest tz-operations-test
-  (testing "to-utc"
-    (is (= {:hour 10 :min 10 :tz 0}
-           (sut/to-utc {:hour 10 :min 10})))
+;; (deftest tz-operations-test
+;;   (testing "to-utc"
+;;     (is (= {:hour 10 :min 10 :tz 0}
+;;            (sut/to-utc {:hour 10 :min 10})))
 
-    (is (= {:hour 10 :min 10 :tz 0}
-           (sut/to-utc {:hour 13 :min 10 :tz 3})))
+;;     (is (= {:hour 10 :min 10 :tz 0}
+;;            (sut/to-utc {:hour 13 :min 10 :tz 3})))
 
-    (is (= {:hour 10 :min 10 :tz 0}
-           (sut/to-utc {:hour 7 :min 10 :tz -3})))
+;;     (is (= {:hour 10 :min 10 :tz 0}
+;;            (sut/to-utc {:hour 7 :min 10 :tz -3})))
 
-    (is (= {:min 10 :tz 0}
-           (sut/to-utc {:min 130 :tz 2})))
+;;     (is (= {:min 10 :tz 0}
+;;            (sut/to-utc {:min 130 :tz 2})))
 
-    (is (= {:day -1 :hour 23 :tz 0}
-           (sut/to-utc {:hour 1 :tz 2})))
+;;     (is (= {:day -1 :hour 23 :tz 0}
+;;            (sut/to-utc {:hour 1 :tz 2})))
 
-    (is (= {:day 1 :hour 1 :tz 0}
-           (sut/to-utc {:hour 23 :tz -2})))
+;;     (is (= {:day 1 :hour 1 :tz 0}
+;;            (sut/to-utc {:hour 23 :tz -2})))
 
-    (is (= {:tz 0}
-           (sut/to-utc {:hour 1 :tz 1}))))
+;;     (is (= {:tz 0}
+;;            (sut/to-utc {:hour 1 :tz 1}))))
 
-  (testing "to-tz"
-    (is (= (sut/to-tz {:hour 10 :min 10} nil)
-           {:hour 10 :min 10}))
+;;   (testing "to-tz"
+;;     (is (= (sut/to-tz {:hour 10 :min 10} nil)
+;;            {:hour 10 :min 10}))
 
-    (is (= (sut/to-tz {:hour 10 :min 10 :tz 0} 3)
-           {:hour 13 :min 10 :tz 3}))
-    (is (= (sut/to-tz {:hour 10 :min 10} 3)
-           {:hour 10 :min 10 :tz 3}))
+;;     (is (= (sut/to-tz {:hour 10 :min 10 :tz 0} 3)
+;;            {:hour 13 :min 10 :tz 3}))
+;;     (is (= (sut/to-tz {:hour 10 :min 10} 3)
+;;            {:hour 10 :min 10 :tz 3}))
 
-    (is (= (sut/to-tz {:hour 10 :min 10 :tz 0} -3)
-           {:hour 7 :min 10 :tz -3}))
-    (is (= (sut/to-tz {:hour 10 :min 10} -3)
-           {:hour 10 :min 10 :tz -3}))
+;;     (is (= (sut/to-tz {:hour 10 :min 10 :tz 0} -3)
+;;            {:hour 7 :min 10 :tz -3}))
+;;     (is (= (sut/to-tz {:hour 10 :min 10} -3)
+;;            {:hour 10 :min 10 :tz -3}))
 
-    (is (= (sut/to-tz {:min 10 :tz 0} 2)
-           {:hour 2 :min 10 :tz 2}))
-    (is (= (sut/to-tz {:min 10} 2)
-           {:min 10 :tz 2}))
+;;     (is (= (sut/to-tz {:min 10 :tz 0} 2)
+;;            {:hour 2 :min 10 :tz 2}))
+;;     (is (= (sut/to-tz {:min 10} 2)
+;;            {:min 10 :tz 2}))
 
-    (is (= (sut/to-tz {:day 1 :hour 1 :tz 0} -2)
-           {:hour 23 :tz -2}))
-    (is (= (sut/to-tz {:day 1 :hour 1} -2)
-           {:day 1 :hour 1 :tz -2}))
+;;     (is (= (sut/to-tz {:day 1 :hour 1 :tz 0} -2)
+;;            {:hour 23 :tz -2}))
+;;     (is (= (sut/to-tz {:day 1 :hour 1} -2)
+;;            {:day 1 :hour 1 :tz -2}))
 
-    (is (= (sut/to-tz {:hour 1 :tz 0} -1)
-           {:tz -1}))
-    (is (= (sut/to-tz {:hour 1} -1)
-           {:hour 1 :tz -1}))))
+;;     (is (= (sut/to-tz {:hour 1 :tz 0} -1)
+;;            {:tz -1}))
+;;     (is (= (sut/to-tz {:hour 1} -1)
+;;            {:hour 1 :tz -1}))))
 
-(deftest comparison-operators-test
-  (testing "="
-    (is (sut/eq? {:year 2011 :month 1 :day 1 :hour 0}))
-    (is (not (sut/eq? {:year 2011 :month 1 :day 2 :hour 0}
-                      {:year 2011 :month 1 :day 1 :hour 0})))
-    (is (sut/eq? {:year 2011 :month 1 :day 1 :hour 1}
-                 {:year 2011 :month 1 :day 1 :hour 1}))
-    (is (not (sut/eq? {:year 2011 :month 1 :day 1 :hour 0}
-                      {:year 2011 :month 1 :day 2 :hour 0}
-                      {:year 2011 :month 1 :day 1 :hour 0})))
-    (is (sut/eq? {:year 2011 :month 1 :day 1 :hour 0}
-                 {:year 2011 :month 1 :day 1 :hour 0}
-                 {:year 2011 :month 1 :day 1 :hour 0})))
-  (testing "= with utc-offset"
-    (is (sut/eq? {:hour 10 :min 10} {:hour 13 :min 10 :tz 3}))
-    (is (not (sut/eq? {:hour 13 :min 10} {:hour 13 :min 10 :tz 3})))
-    (is (sut/eq? {:hour 210 :min 10} {:hour 213 :min 10 :tz 3}))
-    (is (sut/eq? {:hour 15 :min 10} {:hour 13 :min 10 :tz -2}))
-    (is (sut/eq? {:hour 12 :min 10 :tz 2} {:hour 13 :min 10 :tz 3}))
-    (is (sut/eq? {:hour 10 :min 10} {:hour 12 :min 10 :tz 2})))
-  (testing "not="
-    (is (not (sut/not-eq? {:year 2011 :month 1 :day 1 :hour 0})))
-    (is (not (sut/not-eq? {:year 2011 :month 1 :day 1 :hour 0}
-                          {:year 2011 :month 1 :day 1 :hour 0})))
-    (is (sut/not-eq? {:year 2011 :month 1 :day 2 :hour 1}
-                     {:year 2011 :month 1 :day 1 :hour 1}))
-    (is (not (sut/not-eq? {:year 2011 :month 1 :day 1 :hour 0}
-                          {:year 2011 :month 1 :day 1 :hour 0}
-                          {:year 2011 :month 1 :day 1 :hour 0})))
-    (is (sut/not-eq? {:year 2011 :month 1 :day 1 :hour 0}
-                     {:year 2011 :month 1 :day 2 :hour 0}
-                     {:year 2011 :month 1 :day 1 :hour 0})))
-  (testing "not= with utc-offset"
-    (is (not (sut/not-eq? {:hour 10 :min 10} {:hour 13 :min 10 :tz 3})))
-    (is (sut/not-eq? {:hour 13 :min 10} {:hour 13 :min 10 :tz 3}))
-    (is (not (sut/not-eq? {:hour 210 :min 10} {:hour 213 :min 10 :tz 3})))
-    (is (not (sut/not-eq? {:hour 15 :min 10} {:hour 13 :min 10 :tz -2})))
-    (is (not (sut/not-eq? {:hour 12 :min 10 :tz 2} {:hour 13 :min 10 :tz 3})))
-    (is (not (sut/not-eq? {:hour 10 :min 10} {:hour 12 :min 10 :tz 2}))))
-  (testing ">"
-    (is (sut/gt {:year 2011 :month 1 :day 1 :hour 0}))
-    (is (sut/gt {:min 120} {:hour 1}))
-    (is (not (sut/gt {:year 2011 :month 1 :day 1 :hour 0}
-                     {:year 2011 :month 1 :day 2 :hour 0})))
-    (is (sut/gt {:year 2011 :month 1 :day 2 :hour 0}
-                {:year 2011 :month 1 :day 1 :hour 0}))
-    (is (sut/gt {:year 2011 :month 1 :day 2 :hour 0}
-                {:year 2011 :month 1 :day 1 :hour 1}
-                {:year 2011 :month 1 :day 1 :hour 0})))
-  (testing "> with utc-offset"
-    (is (sut/gt {:hour 13} {:hour 13 :tz 3}))
-    (is (not (sut/gt {:hour 13 :tz 3} {:hour 13})))
-    (is (sut/gt {:hour 13 :tz -3} {:hour 13}))
-    (is (not (sut/gt {:hour 13} {:hour 13 :tz -3})))
-    (is (sut/gt {:hour 13 :tz -3} {:hour 13 :tz -2}))
-    (is (not (sut/gt {:hour 13 :tz -2} {:hour 13 :tz -3})))
-    (is (not (sut/gt {:hour 10 :min 10} {:hour 13 :min 10 :tz 3}))))
-  (testing "<"
-    (is (sut/lt {:year 2011 :month 1 :day 1 :hour 0}))
-    (is (sut/lt {:hour 1} {:min 120}))
-    (is (not (sut/lt {:year 2011 :month 1 :day 2 :hour 0}
-                     {:year 2011 :month 1 :day 1 :hour 0})))
-    (is (sut/lt {:year 2011 :month 1 :day 1 :hour 0}
-                {:year 2011 :month 1 :day 2 :hour 0}))
-    (is (sut/lt {:year 2011 :month 1 :day 1 :hour 0}
-                {:year 2011 :month 1 :day 1 :hour 1}
-                {:year 2011 :month 1 :day 2 :hour 0})))
-  (testing "< with utc-offset"
-    (is (sut/lt {:hour 13 :tz 3} {:hour 13}))
-    (is (not (sut/lt {:hour 13} {:hour 13 :tz 3})))
-    (is (sut/lt {:hour 13} {:hour 13 :tz -3}))
-    (is (not (sut/lt {:hour 13 :tz -3} {:hour 13})))
-    (is (sut/lt {:hour 13 :tz -2} {:hour 13 :tz -3}))
-    (is (not (sut/lt {:hour 13 :tz -3} {:hour 13 :tz -2})))
-    (is (not (sut/lt {:hour 13 :min 10 :tz 3} {:hour 10 :min 10}))))
-  (testing "<="
-    (is (sut/lte {:year 2011 :month 1 :day 1 :hour 0}))
-    (is (sut/lte {:year 2011 :month 1 :day 1 :hour 0}
-                 {:year 2011 :month 1 :day 2 :hour 0}))
-    (is (sut/lte {:year 2011 :month 1 :day 1 :hour 0}
-                 {:year 2011 :month 1 :day 1 :hour 0}))
-    (is (not (sut/lte {:year 2011 :month 1 :day 2 :hour 0}
-                      {:year 2011 :month 1 :day 1 :hour 0})))
-    (is (sut/lte {:year 2011 :month 1 :day 1 :hour 0}
-                 {:year 2011 :month 1 :day 1 :hour 0}
-                 {:year 2011 :month 1 :day 2 :hour 0})))
-  (testing ">="
-    (is (sut/gte {:year 2011 :month 1 :day 1 :hour 0}))
-    (is (sut/gte {:year 2011 :month 1 :day 2 :hour 0}
-                 {:year 2011 :month 1 :day 1 :hour 0}))
-    (is (sut/gte {:year 2011 :month 1 :day 2 :hour 1}
-                 {:year 2011 :month 1 :day 1 :hour 1}
-                 {:year 2011 :month 1 :day 1 :hour 0}))
-    (is (not (sut/gte {:year 2011 :month 1 :day 1 :hour 0}
-                      {:year 2011 :month 1 :day 2 :hour 0})))
-    (is (sut/gte {:year 2011 :month 1 :day 2 :hour 0}
-                 {:year 2011 :month 1 :day 1 :hour 0}
-                 {:year 2011 :month 1 :day 1 :hour 0}))))
+;; (deftest comparison-operators-test
+;;   (testing "="
+;;     (is (sut/eq? {:year 2011 :month 1 :day 1 :hour 0}))
+;;     (is (not (sut/eq? {:year 2011 :month 1 :day 2 :hour 0}
+;;                       {:year 2011 :month 1 :day 1 :hour 0})))
+;;     (is (sut/eq? {:year 2011 :month 1 :day 1 :hour 1}
+;;                  {:year 2011 :month 1 :day 1 :hour 1}))
+;;     (is (not (sut/eq? {:year 2011 :month 1 :day 1 :hour 0}
+;;                       {:year 2011 :month 1 :day 2 :hour 0}
+;;                       {:year 2011 :month 1 :day 1 :hour 0})))
+;;     (is (sut/eq? {:year 2011 :month 1 :day 1 :hour 0}
+;;                  {:year 2011 :month 1 :day 1 :hour 0}
+;;                  {:year 2011 :month 1 :day 1 :hour 0})))
+;;   (testing "= with utc-offset"
+;;     (is (sut/eq? {:hour 10 :min 10} {:hour 13 :min 10 :tz 3}))
+;;     (is (not (sut/eq? {:hour 13 :min 10} {:hour 13 :min 10 :tz 3})))
+;;     (is (sut/eq? {:hour 210 :min 10} {:hour 213 :min 10 :tz 3}))
+;;     (is (sut/eq? {:hour 15 :min 10} {:hour 13 :min 10 :tz -2}))
+;;     (is (sut/eq? {:hour 12 :min 10 :tz 2} {:hour 13 :min 10 :tz 3}))
+;;     (is (sut/eq? {:hour 10 :min 10} {:hour 12 :min 10 :tz 2})))
+;;   (testing "not="
+;;     (is (not (sut/not-eq? {:year 2011 :month 1 :day 1 :hour 0})))
+;;     (is (not (sut/not-eq? {:year 2011 :month 1 :day 1 :hour 0}
+;;                           {:year 2011 :month 1 :day 1 :hour 0})))
+;;     (is (sut/not-eq? {:year 2011 :month 1 :day 2 :hour 1}
+;;                      {:year 2011 :month 1 :day 1 :hour 1}))
+;;     (is (not (sut/not-eq? {:year 2011 :month 1 :day 1 :hour 0}
+;;                           {:year 2011 :month 1 :day 1 :hour 0}
+;;                           {:year 2011 :month 1 :day 1 :hour 0})))
+;;     (is (sut/not-eq? {:year 2011 :month 1 :day 1 :hour 0}
+;;                      {:year 2011 :month 1 :day 2 :hour 0}
+;;                      {:year 2011 :month 1 :day 1 :hour 0})))
+;;   (testing "not= with utc-offset"
+;;     (is (not (sut/not-eq? {:hour 10 :min 10} {:hour 13 :min 10 :tz 3})))
+;;     (is (sut/not-eq? {:hour 13 :min 10} {:hour 13 :min 10 :tz 3}))
+;;     (is (not (sut/not-eq? {:hour 210 :min 10} {:hour 213 :min 10 :tz 3})))
+;;     (is (not (sut/not-eq? {:hour 15 :min 10} {:hour 13 :min 10 :tz -2})))
+;;     (is (not (sut/not-eq? {:hour 12 :min 10 :tz 2} {:hour 13 :min 10 :tz 3})))
+;;     (is (not (sut/not-eq? {:hour 10 :min 10} {:hour 12 :min 10 :tz 2}))))
+;;   (testing ">"
+;;     (is (sut/gt {:year 2011 :month 1 :day 1 :hour 0}))
+;;     (is (sut/gt {:min 120} {:hour 1}))
+;;     (is (not (sut/gt {:year 2011 :month 1 :day 1 :hour 0}
+;;                      {:year 2011 :month 1 :day 2 :hour 0})))
+;;     (is (sut/gt {:year 2011 :month 1 :day 2 :hour 0}
+;;                 {:year 2011 :month 1 :day 1 :hour 0}))
+;;     (is (sut/gt {:year 2011 :month 1 :day 2 :hour 0}
+;;                 {:year 2011 :month 1 :day 1 :hour 1}
+;;                 {:year 2011 :month 1 :day 1 :hour 0})))
+;;   (testing "> with utc-offset"
+;;     (is (sut/gt {:hour 13} {:hour 13 :tz 3}))
+;;     (is (not (sut/gt {:hour 13 :tz 3} {:hour 13})))
+;;     (is (sut/gt {:hour 13 :tz -3} {:hour 13}))
+;;     (is (not (sut/gt {:hour 13} {:hour 13 :tz -3})))
+;;     (is (sut/gt {:hour 13 :tz -3} {:hour 13 :tz -2}))
+;;     (is (not (sut/gt {:hour 13 :tz -2} {:hour 13 :tz -3})))
+;;     (is (not (sut/gt {:hour 10 :min 10} {:hour 13 :min 10 :tz 3}))))
+;;   (testing "<"
+;;     (is (sut/lt {:year 2011 :month 1 :day 1 :hour 0}))
+;;     (is (sut/lt {:hour 1} {:min 120}))
+;;     (is (not (sut/lt {:year 2011 :month 1 :day 2 :hour 0}
+;;                      {:year 2011 :month 1 :day 1 :hour 0})))
+;;     (is (sut/lt {:year 2011 :month 1 :day 1 :hour 0}
+;;                 {:year 2011 :month 1 :day 2 :hour 0}))
+;;     (is (sut/lt {:year 2011 :month 1 :day 1 :hour 0}
+;;                 {:year 2011 :month 1 :day 1 :hour 1}
+;;                 {:year 2011 :month 1 :day 2 :hour 0})))
+;;   (testing "< with utc-offset"
+;;     (is (sut/lt {:hour 13 :tz 3} {:hour 13}))
+;;     (is (not (sut/lt {:hour 13} {:hour 13 :tz 3})))
+;;     (is (sut/lt {:hour 13} {:hour 13 :tz -3}))
+;;     (is (not (sut/lt {:hour 13 :tz -3} {:hour 13})))
+;;     (is (sut/lt {:hour 13 :tz -2} {:hour 13 :tz -3}))
+;;     (is (not (sut/lt {:hour 13 :tz -3} {:hour 13 :tz -2})))
+;;     (is (not (sut/lt {:hour 13 :min 10 :tz 3} {:hour 10 :min 10}))))
+;;   (testing "<="
+;;     (is (sut/lte {:year 2011 :month 1 :day 1 :hour 0}))
+;;     (is (sut/lte {:year 2011 :month 1 :day 1 :hour 0}
+;;                  {:year 2011 :month 1 :day 2 :hour 0}))
+;;     (is (sut/lte {:year 2011 :month 1 :day 1 :hour 0}
+;;                  {:year 2011 :month 1 :day 1 :hour 0}))
+;;     (is (not (sut/lte {:year 2011 :month 1 :day 2 :hour 0}
+;;                       {:year 2011 :month 1 :day 1 :hour 0})))
+;;     (is (sut/lte {:year 2011 :month 1 :day 1 :hour 0}
+;;                  {:year 2011 :month 1 :day 1 :hour 0}
+;;                  {:year 2011 :month 1 :day 2 :hour 0})))
+;;   (testing ">="
+;;     (is (sut/gte {:year 2011 :month 1 :day 1 :hour 0}))
+;;     (is (sut/gte {:year 2011 :month 1 :day 2 :hour 0}
+;;                  {:year 2011 :month 1 :day 1 :hour 0}))
+;;     (is (sut/gte {:year 2011 :month 1 :day 2 :hour 1}
+;;                  {:year 2011 :month 1 :day 1 :hour 1}
+;;                  {:year 2011 :month 1 :day 1 :hour 0}))
+;;     (is (not (sut/gte {:year 2011 :month 1 :day 1 :hour 0}
+;;                       {:year 2011 :month 1 :day 2 :hour 0})))
+;;     (is (sut/gte {:year 2011 :month 1 :day 2 :hour 0}
+;;                  {:year 2011 :month 1 :day 1 :hour 0}
+;;                  {:year 2011 :month 1 :day 1 :hour 0}))))
 
 (deftest arithmetic-operations-test
   (testing "+"
     (def t
-      {:year  2018
-       :month 1
-       :day   1
-       :hour  12
-       :min   30
-       :sec   30
-       :ms    500})
+      {::ch/year  2018
+       ::ch/month 1
+       ::ch/day   1
+       ::ch/hour  12
+       ::ch/min   30
+       ::ch/sec   30
+       ::ch/ms    500})
 
-    (matcho/match (sut/plus t {:ms 200})
-                  {:ms 700})
+    (matcho/match (sut/plus t {::ci/ms 200})
+                  {::ch/ms 700})))
 
-    (matcho/match (sut/plus t {:ms 600})
-                  {:ms  100
-                   :sec 31})
+;; (deftest arithmetic-operations-test
+;;   (testing "+"
+;;     (def t
+;;       #_{::ch/year  2018
+;;        ::ch/month 1
+;;        ::ch/day   1
+;;        ::ch/hour  12
+;;        ::ch/min   30
+;;        ::ch/sec   30
+;;        ::ch/ms    500})
 
-    (is (= (sut/plus {:ms 600} {:ms 600} {:ms 300})
-           {:ms  500
-            :sec 1}))
+;;     (matcho/match (sut/plus t {::ch/ms 200})
+;;                   {::ch/ms 700})
 
-    (matcho/match (sut/plus t {:sec 20})
-                  {:sec 50})
+;;     #_(matcho/match (sut/plus t {:ms 600})
+;;                   {:ms  100
+;;                    :sec 31})
 
-    (matcho/match (sut/plus t {:sec 20})
-                  {:sec 50})
+;;     (is (= (sut/plus {:ms 600} {:ms 600} {:ms 300})
+;;            {:ms  500
+;;             :sec 1}))
 
-    (matcho/match (sut/plus t {:min 20})
-                  {:hour 12
-                   :min  50})
+;;     (matcho/match (sut/plus t {:sec 20})
+;;                   {:sec 50})
 
-    (matcho/match (sut/plus t {:min 30})
-                  {:hour 13})
+;;     (matcho/match (sut/plus t {:sec 20})
+;;                   {:sec 50})
 
-    (is (= (sut/plus {:year 2018 :month 12 :day 31} {:day 1})
-           {:year 2019 :month 1 :day 1}))
+;;     (matcho/match (sut/plus t {:min 20})
+;;                   {:hour 12
+;;                    :min  50})
 
-    (is (= (sut/plus {:year 2018 :month 1 :day 1} {:day 31})
-           {:year 2018 :month 2 :day 1}))
+;;     (matcho/match (sut/plus t {:min 30})
+;;                   {:hour 13})
 
-    (is (= (sut/plus {:year 2018 :month 12 :day 31} {:day 366})
-           {:year 2020 :month 1 :day 1}))
+;;     (is (= (sut/plus {:year 2018 :month 12 :day 31} {:day 1})
+;;            {:year 2019 :month 1 :day 1}))
 
-    (is (= (sut/plus {:year 2018 :month 2 :day 28} {:day 1})
-           {:year 2018 :month 3 :day 1}))
+;;     (is (= (sut/plus {:year 2018 :month 1 :day 1} {:day 31})
+;;            {:year 2018 :month 2 :day 1}))
 
-    (is (= (sut/plus {:year 2018 :month 3 :day 30} {:day 1})
-           {:year 2018 :month 3 :day 31}))
+;;     (is (= (sut/plus {:year 2018 :month 12 :day 31} {:day 366})
+;;            {:year 2020 :month 1 :day 1}))
 
-    (is (= (sut/plus {:year 2018 :month 3 :day 31} {:day 1})
-           {:year 2018 :month 4 :day 1}))
+;;     (is (= (sut/plus {:year 2018 :month 2 :day 28} {:day 1})
+;;            {:year 2018 :month 3 :day 1}))
 
-    (is (= (sut/plus {:ms 100} {:ms 300})
-           {:ms 400}))
+;;     (is (= (sut/plus {:year 2018 :month 3 :day 30} {:day 1})
+;;            {:year 2018 :month 3 :day 31}))
 
-    (is (= (sut/plus {:ms 900} {:ms 300})
-           {:ms 200 :sec 1}))
+;;     (is (= (sut/plus {:year 2018 :month 3 :day 31} {:day 1})
+;;            {:year 2018 :month 4 :day 1}))
 
-    (is (= (sut/plus {:sec 40} {:sec 50})
-           {:sec 30 :min 1}))
+;;     (is (= (sut/plus {:ms 100} {:ms 300})
+;;            {:ms 400}))
 
-    (is (= (sut/plus {:min 40} {:min 50})
-           {:min 30 :hour 1}))
+;;     (is (= (sut/plus {:ms 900} {:ms 300})
+;;            {:ms 200 :sec 1}))
 
-    (is (= (sut/plus {:hour 13} {:hour 14})
-           {:hour 3 :day 1}))
+;;     (is (= (sut/plus {:sec 40} {:sec 50})
+;;            {:sec 30 :min 1}))
 
-    (is (= (sut/plus {:year 2011 :month 1 :day 1 :hour 23} {:hour 5})
-           {:year 2011 :month 1 :day 2 :hour 4}))
+;;     (is (= (sut/plus {:min 40} {:min 50})
+;;            {:min 30 :hour 1}))
 
-    (is (= (sut/plus {:year 2011 :month 1 :day 30} {:day 3})
-           {:year 2011 :month 2 :day 2}))
+;;     (is (= (sut/plus {:hour 13} {:hour 14})
+;;            {:hour 3 :day 1}))
 
-    (is (= (sut/plus {:year 2011 :month 1 :day 1} {:day 365})
-           {:year 2012 :month 1 :day 1}))
+;;     (is (= (sut/plus {:year 2011 :month 1 :day 1 :hour 23} {:hour 5})
+;;            {:year 2011 :month 1 :day 2 :hour 4}))
 
-    (is (= (sut/plus {:year 2011 :month 12 :day 31 :hour 23} {:hour 5})
-           {:year 2012 :month 1 :day 1 :hour 4}))
+;;     (is (= (sut/plus {:year 2011 :month 1 :day 30} {:day 3})
+;;            {:year 2011 :month 2 :day 2}))
 
-    (is (= (sut/plus {:year 2011 :month 1 :day 1 :hour 0} {:hour -1})
-           {:year 2010 :month 12 :day 31 :hour 23}))
+;;     (is (= (sut/plus {:year 2011 :month 1 :day 1} {:day 365})
+;;            {:year 2012 :month 1 :day 1}))
 
-    (is (= (sut/plus {:year 2011 :month 1 :day 1 :hour 0} {:sec -1})
-           {:year 2010 :month 12 :day 31 :hour 23 :min 59 :sec 59}))
+;;     (is (= (sut/plus {:year 2011 :month 12 :day 31 :hour 23} {:hour 5})
+;;            {:year 2012 :month 1 :day 1 :hour 4}))
 
-    (is (= (sut/plus {:year 2011 :month 1 :day 1 :hour 0} {:ms -1})
-           {:year 2010 :month 12 :day 31 :hour 23 :min 59 :sec 59 :ms 999}))
+;;     (is (= (sut/plus {:year 2011 :month 1 :day 1 :hour 0} {:hour -1})
+;;            {:year 2010 :month 12 :day 31 :hour 23}))
 
-    (is (= (sut/plus {:year 2011 :month 1 :day 1 :hour 23} {:hour -23 :min -30})
-           {:year 2010 :month 12 :day 31 :hour 23 :min 30}))
+;;     (is (= (sut/plus {:year 2011 :month 1 :day 1 :hour 0} {:sec -1})
+;;            {:year 2010 :month 12 :day 31 :hour 23 :min 59 :sec 59}))
 
-    (is (= (sut/plus {:year 2019 :month 11 :day 1} {:month 1})
-           {:year 2019 :month 12 :day 1}))
+;;     (is (= (sut/plus {:year 2011 :month 1 :day 1 :hour 0} {:ms -1})
+;;            {:year 2010 :month 12 :day 31 :hour 23 :min 59 :sec 59 :ms 999}))
 
-    (is (= (sut/plus {:year 2019 :month 11 :day 1} {:month 2})
-           {:year 2020 :month 1 :day 1}))
+;;     (is (= (sut/plus {:year 2011 :month 1 :day 1 :hour 23} {:hour -23 :min -30})
+;;            {:year 2010 :month 12 :day 31 :hour 23 :min 30}))
 
-    (is (= (sut/plus {:year 2019 :month 12 :day 1} {:month 1})
-           {:year 2020 :month 1 :day 1}))
+;;     (is (= (sut/plus {:year 2019 :month 11 :day 1} {:month 1})
+;;            {:year 2019 :month 12 :day 1}))
 
-    (is (= (sut/plus {:year 2019 :month 11 :day 32} {:month 1})
-           {:year 2020 :month 1 :day 1}))
+;;     (is (= (sut/plus {:year 2019 :month 11 :day 1} {:month 2})
+;;            {:year 2020 :month 1 :day 1}))
 
-    (is (= (sut/plus {:year 2019, :month 12, :day 10, :hour 13, :min 17, :sec 50, :ms 911} {:hour 2})
-           {:year 2019, :month 12, :day 10, :hour 15, :min 17, :sec 50, :ms 911}))
+;;     (is (= (sut/plus {:year 2019 :month 12 :day 1} {:month 1})
+;;            {:year 2020 :month 1 :day 1}))
 
-    (is (= (sut/plus {:hour 4 :tz 2} {:hour 10})
-           {:hour 14 :tz 2}))
+;;     (is (= (sut/plus {:year 2019 :month 11 :day 32} {:month 1})
+;;            {:year 2020 :month 1 :day 1}))
 
-    (is (= (sut/plus {:hour 23 :tz -2} {:hour 1})
-           {:day 1 :tz -2}))
+;;     (is (= (sut/plus {:year 2019, :month 12, :day 10, :hour 13, :min 17, :sec 50, :ms 911} {:hour 2})
+;;            {:year 2019, :month 12, :day 10, :hour 15, :min 17, :sec 50, :ms 911}))
 
-    (is (= (sut/plus {:hour 1 :tz -2} {:hour 1})
-           {:hour 2 :tz -2}))
+;;     (is (= (sut/plus {:hour 4 :tz 2} {:hour 10})
+;;            {:hour 14 :tz 2}))
 
-    (testing "with custom units"
-      (def normalize-ns (sut/gen-norm :ns :ms 1000000 0))
-      (defmethod sut/normalize-rule :ns [_ t] (normalize-ns t))
+;;     (is (= (sut/plus {:hour 23 :tz -2} {:hour 1})
+;;            {:day 1 :tz -2}))
 
-      (is (= (sut/plus {:ns 10} {:ns 1})
-             {:ns 11}))
+;;     (is (= (sut/plus {:hour 1 :tz -2} {:hour 1})
+;;            {:hour 2 :tz -2}))
 
-      (is (= (sut/plus {:ns 999999999} {:ns 1})
-             {:sec 1}))
+;;     (testing "with custom units"
+;;       (def normalize-ns (sut/gen-norm :ns :ms 1000000 0))
+;;       (defmethod sut/normalize-rule :ns [_ t] (normalize-ns t))
 
-      (is (= (sut/plus {:ns 9999999} {:ns 999000001})
-             {:sec 1 :ms 9}))
+;;       (is (= (sut/plus {:ns 10} {:ns 1})
+;;              {:ns 11}))
 
-      (is (= (sut/plus {:year 2019 :month 12 :day 31 :hour 23 :min 59 :sec 59 :ns 999999999} {:ns 1})
-             {:year 2020 :month 1 :day 1}))))
+;;       (is (= (sut/plus {:ns 999999999} {:ns 1})
+;;              {:sec 1}))
 
-  (testing "-"
-    (is (= (sut/minus {:year 2016 :month 12 :day 31 :hour 23 :min 30} {:day 365})
-           {:year 2016, :month 1, :day 1, :hour 23, :min 30}))
+;;       (is (= (sut/plus {:ns 9999999} {:ns 999000001})
+;;              {:sec 1 :ms 9}))
 
-    (is (= (sut/minus {:year 2016 :month 12 :day 31 :hour 23 :min 30} {:day 366})
-           {:year 2015, :month 12, :day 31, :hour 23, :min 30}))
-    (is (= (sut/minus {:hour 2 :tz -2} {:hour 2})
-           {:tz -2}))
-    (is (= (sut/minus {:hour 3 :tz 2} {:hour 1 :tz 2})
-           {:hour 2 :tz 2}))))
+;;       (is (= (sut/plus {:year 2019 :month 12 :day 31 :hour 23 :min 59 :sec 59 :ns 999999999} {:ns 1})
+;;              {:year 2020 :month 1 :day 1}))))
 
-(deftest test-timezones
-  (testing "tz comparison"
-    (is (sut/lte {:year 2018 :month 5 :day 2 :hour 14 :tz :ny}
-                 {:year 2018 :month 5 :day 2 :hour 14 :tz :ny}))
+;;   (testing "-"
+;;     (is (= (sut/minus {:year 2016 :month 12 :day 31 :hour 23 :min 30} {:day 365})
+;;            {:year 2016, :month 1, :day 1, :hour 23, :min 30}))
 
-    (is (sut/lte {:year 2018 :month 5 :day 2 :hour 14 :tz :ny}
-                 {:year 2018 :month 5 :day 2 :hour 14 :sec 1 :tz :ny}))
+;;     (is (= (sut/minus {:year 2016 :month 12 :day 31 :hour 23 :min 30} {:day 366})
+;;            {:year 2015, :month 12, :day 31, :hour 23, :min 30}))
+;;     (is (= (sut/minus {:hour 2 :tz -2} {:hour 2})
+;;            {:tz -2}))
+;;     (is (= (sut/minus {:hour 3 :tz 2} {:hour 1 :tz 2})
+;;            {:hour 2 :tz 2}))))
 
-    (is (sut/gt {:year 2018 :month 5 :day 2 :hour 14 :sec 1 :tz :ny}
-                {:year 2018 :month 5 :day 2 :hour 14 :tz :ny}))
+;; (deftest test-timezones
+;;   (testing "tz comparison"
+;;     (is (sut/lte {:year 2018 :month 5 :day 2 :hour 14 :tz :ny}
+;;                  {:year 2018 :month 5 :day 2 :hour 14 :tz :ny}))
 
-    (is (sut/gt {:year 2018 :month 5 :day 2 :hour 13 :min 120 :tz :ny}
-                {:year 2018 :month 5 :day 2 :hour 14 :tz :ny}))
+;;     (is (sut/lte {:year 2018 :month 5 :day 2 :hour 14 :tz :ny}
+;;                  {:year 2018 :month 5 :day 2 :hour 14 :sec 1 :tz :ny}))
 
-    (is (sut/lte {:year 2018 :month 5 :day 2 :hour 14 :tz :ny}
-                 {:year 2018 :month 5 :day 2 :hour 13 :min 120 :tz :ny}))
+;;     (is (sut/gt {:year 2018 :month 5 :day 2 :hour 14 :sec 1 :tz :ny}
+;;                 {:year 2018 :month 5 :day 2 :hour 14 :tz :ny}))
 
-    (is (sut/lte {:year 2018 :month 5 :day 2 :hour 14 :tz :ny}
-                 {:year 2018 :month 11}))
+;;     (is (sut/gt {:year 2018 :month 5 :day 2 :hour 13 :min 120 :tz :ny}
+;;                 {:year 2018 :month 5 :day 2 :hour 14 :tz :ny}))
 
-    (is (sut/gt {:year 2018 :month 11}
-                {:year 2018 :month 5 :day 2 :hour 14 :tz :ny})))
+;;     (is (sut/lte {:year 2018 :month 5 :day 2 :hour 14 :tz :ny}
+;;                  {:year 2018 :month 5 :day 2 :hour 13 :min 120 :tz :ny}))
 
-  (matcho/match (sut/day-saving :ny 2017)
-                {:in  {:month 3 :day 12 :hour 2 :min 0}
-                 :out {:month 11 :day 5 :hour 2}})
+;;     (is (sut/lte {:year 2018 :month 5 :day 2 :hour 14 :tz :ny}
+;;                  {:year 2018 :month 11}))
 
-  (matcho/match (sut/day-saving-with-utc :ny 2017)
-                {:in     {:month 3 :day 12 :hour 2 :min 0}
-                 :in-utc {:month 3 :day 12 :hour 7}
+;;     (is (sut/gt {:year 2018 :month 11}
+;;                 {:year 2018 :month 5 :day 2 :hour 14 :tz :ny})))
 
-                 :out     {:month 11 :day 5 :hour 2}
-                 :out-utc {:month 11 :day 5 :hour 6}})
+;;   (matcho/match (sut/day-saving :ny 2017)
+;;                 {:in  {:month 3 :day 12 :hour 2 :min 0}
+;;                  :out {:month 11 :day 5 :hour 2}})
 
-  (matcho/match (sut/day-saving-with-utc :ny 2018)
-                {:in  {:month 3 :day 11}
-                 :out {:month 11 :day 4}})
+;;   (matcho/match (sut/day-saving-with-utc :ny 2017)
+;;                 {:in     {:month 3 :day 12 :hour 2 :min 0}
+;;                  :in-utc {:month 3 :day 12 :hour 7}
 
-  (matcho/match (sut/day-saving-with-utc :ny 2019)
-                {:in  {:month 3 :day 10}
-                 :out {:month 11 :day 3}})
+;;                  :out     {:month 11 :day 5 :hour 2}
+;;                  :out-utc {:month 11 :day 5 :hour 6}})
 
-  (is (= (sut/to-utc {:year 2018 :month 5 :day 2 :hour 14 :tz :ny})
-         {:year 2018 :month 5 :day 2 :hour 18 :tz 0}))
+;;   (matcho/match (sut/day-saving-with-utc :ny 2018)
+;;                 {:in  {:month 3 :day 11}
+;;                  :out {:month 11 :day 4}})
 
-  (is (= (sut/to-tz {:year 2018 :month 5 :day 2 :hour 18 :tz 0} :ny)
-         {:year 2018 :month 5 :day 2 :hour 14 :tz :ny}))
+;;   (matcho/match (sut/day-saving-with-utc :ny 2019)
+;;                 {:in  {:month 3 :day 10}
+;;                  :out {:month 11 :day 3}})
 
-  (is (= (sut/to-tz {:year 2018 :month 5 :day 2 :hour 18} :ny)
-         {:year 2018 :month 5 :day 2 :hour 18 :tz :ny}))
+;;   (is (= (sut/to-utc {:year 2018 :month 5 :day 2 :hour 14 :tz :ny})
+;;          {:year 2018 :month 5 :day 2 :hour 18 :tz 0}))
 
-  (is (= (sut/to-utc {:year 2018 :month 2 :day 2 :hour 14 :tz :ny})
-         {:year 2018 :month 2 :day 2 :hour 19 :tz 0}))
+;;   (is (= (sut/to-tz {:year 2018 :month 5 :day 2 :hour 18 :tz 0} :ny)
+;;          {:year 2018 :month 5 :day 2 :hour 14 :tz :ny}))
 
-  (is (= (sut/to-tz {:year 2018 :month 2 :day 2 :hour 19 :tz 0} :ny)
-         {:year 2018 :month 2 :day 2 :hour 14 :tz :ny}))
+;;   (is (= (sut/to-tz {:year 2018 :month 5 :day 2 :hour 18} :ny)
+;;          {:year 2018 :month 5 :day 2 :hour 18 :tz :ny}))
 
-  (is (= (sut/to-tz {:year 2018 :month 2 :day 2 :hour 19} :ny)
-         {:year 2018 :month 2 :day 2 :hour 19 :tz :ny})))
+;;   (is (= (sut/to-utc {:year 2018 :month 2 :day 2 :hour 14 :tz :ny})
+;;          {:year 2018 :month 2 :day 2 :hour 19 :tz 0}))
+
+;;   (is (= (sut/to-tz {:year 2018 :month 2 :day 2 :hour 19 :tz 0} :ny)
+;;          {:year 2018 :month 2 :day 2 :hour 14 :tz :ny}))
+
+;;   (is (= (sut/to-tz {:year 2018 :month 2 :day 2 :hour 19} :ny)
+;;          {:year 2018 :month 2 :day 2 :hour 19 :tz :ny})))

--- a/test/chrono/ops_test.clj
+++ b/test/chrono/ops_test.clj
@@ -507,25 +507,6 @@
     (is (sut/gt #::cd{:year 2018 :month 11}
                 #::cd{:year 2018 :month 5 :day 2 :hour 14 :tz :ny})))
 
-  (matcho/match (sut/day-saving :ny 2017)
-                {:in  #::cd{:month 3 :day 12 :hour 2 :min 0}
-                 :out #::cd{:month 11 :day 5 :hour 2}})
-
-  (matcho/match (sut/day-saving-with-utc :ny 2017)
-                {:in     #::cd{:month 3 :day 12 :hour 2 :min 0}
-                 :in-utc #::cd{:month 3 :day 12 :hour 7}
-
-                 :out     #::cd{:month 11 :day 5 :hour 2}
-                 :out-utc #::cd{:month 11 :day 5 :hour 6}})
-
-  (matcho/match (sut/day-saving-with-utc :ny 2018)
-                {:in  #::cd{:month 3 :day 11}
-                 :out #::cd{:month 11 :day 4}})
-
-  (matcho/match (sut/day-saving-with-utc :ny 2019)
-                {:in  #::cd{:month 3 :day 10}
-                 :out #::cd{:month 11 :day 3}})
-
   (is (= #::cd{:year 2018 :month 5 :day 2 :hour 18 :tz 0}
          (sut/to-utc #::cd{:year 2018 :month 5 :day 2 :hour 14 :tz :ny})))
 

--- a/test/chrono/ops_test.clj
+++ b/test/chrono/ops_test.clj
@@ -21,156 +21,158 @@
 
   (is (= [2012 1 1] (sut/days-and-months 2013 1 -365))))
 
-;; (deftest tz-operations-test
-;;   (testing "to-utc"
-;;     (is (= {:hour 10 :min 10 :tz 0}
-;;            (sut/to-utc {:hour 10 :min 10})))
+(deftest tz-operations-test
+  (testing "to-utc"
+    (is (= #::cd{:hour 10 :min 10 :tz 0}
+           (sut/to-utc #::cd{:hour 10 :min 10})))
 
-;;     (is (= {:hour 10 :min 10 :tz 0}
-;;            (sut/to-utc {:hour 13 :min 10 :tz 3})))
+    (is (= #::cd{:hour 10 :min 10 :tz 0}
+           (sut/to-utc #::cd{:hour 13 :min 10 :tz 3})))
 
-;;     (is (= {:hour 10 :min 10 :tz 0}
-;;            (sut/to-utc {:hour 7 :min 10 :tz -3})))
+    (is (= #::cd{:hour 10 :min 10 :tz 0}
+           (sut/to-utc #::cd{:hour 7 :min 10 :tz -3})))
 
-;;     (is (= {:min 10 :tz 0}
-;;            (sut/to-utc {:min 130 :tz 2})))
+    (is (= #::cd{:min 10 :tz 0}
+           (sut/to-utc #::cd{:min 130 :tz 2})))
 
-;;     (is (= {:day -1 :hour 23 :tz 0}
-;;            (sut/to-utc {:hour 1 :tz 2})))
+    (is (= #::cd{:day -1 :hour 23 :tz 0}
+           (sut/to-utc #::cd{:hour 1 :tz 2})))
 
-;;     (is (= {:day 1 :hour 1 :tz 0}
-;;            (sut/to-utc {:hour 23 :tz -2})))
+    (is (= #::cd{:day 1 :hour 1 :tz 0}
+           (sut/to-utc #::cd{:hour 23 :tz -2})))
 
-;;     (is (= {:tz 0}
-;;            (sut/to-utc {:hour 1 :tz 1}))))
+    (is (= #::cd{:tz 0}
+           (sut/to-utc #::cd{:hour 1 :tz 1}))))
 
-;;   (testing "to-tz"
-;;     (is (= (sut/to-tz {:hour 10 :min 10} nil)
-;;            {:hour 10 :min 10}))
+  (testing "to-tz"
+    (is (= #::cd{:hour 10 :min 10}
+           (sut/to-tz #::cd{:hour 10 :min 10} nil)))
 
-;;     (is (= (sut/to-tz {:hour 10 :min 10 :tz 0} 3)
-;;            {:hour 13 :min 10 :tz 3}))
-;;     (is (= (sut/to-tz {:hour 10 :min 10} 3)
-;;            {:hour 10 :min 10 :tz 3}))
+    (is (= #::cd{:hour 13 :min 10 :tz 3}
+           (sut/to-tz #::cd{:hour 10 :min 10 :tz 0} 3)))
+    (is (= #::cd{:hour 10 :min 10 :tz 3}
+           (sut/to-tz #::cd{:hour 10 :min 10} 3)))
 
-;;     (is (= (sut/to-tz {:hour 10 :min 10 :tz 0} -3)
-;;            {:hour 7 :min 10 :tz -3}))
-;;     (is (= (sut/to-tz {:hour 10 :min 10} -3)
-;;            {:hour 10 :min 10 :tz -3}))
+    (is (= #::cd{:hour 7 :min 10 :tz -3}
+           (sut/to-tz #::cd{:hour 10 :min 10 :tz 0} -3)))
+    (is (= #::cd{:hour 10 :min 10 :tz -3}
+           (sut/to-tz #::cd{:hour 10 :min 10} -3)))
 
-;;     (is (= (sut/to-tz {:min 10 :tz 0} 2)
-;;            {:hour 2 :min 10 :tz 2}))
-;;     (is (= (sut/to-tz {:min 10} 2)
-;;            {:min 10 :tz 2}))
+    (is (= #::cd{:hour 2 :min 10 :tz 2}
+           (sut/to-tz #::cd{:min 10 :tz 0} 2)))
+    (is (= #::cd{:min 10 :tz 2}
+           (sut/to-tz #::cd{:min 10} 2)))
 
-;;     (is (= (sut/to-tz {:day 1 :hour 1 :tz 0} -2)
-;;            {:hour 23 :tz -2}))
-;;     (is (= (sut/to-tz {:day 1 :hour 1} -2)
-;;            {:day 1 :hour 1 :tz -2}))
+    (is (= #::cd{:hour 23 :tz -2}
+           (sut/to-tz #::cd{:day 1 :hour 1 :tz 0} -2)))
+    (is (= #::cd{:day 1 :hour 1 :tz -2}
+           (sut/to-tz #::cd{:day 1 :hour 1} -2)))
 
-;;     (is (= (sut/to-tz {:hour 1 :tz 0} -1)
-;;            {:tz -1}))
-;;     (is (= (sut/to-tz {:hour 1} -1)
-;;            {:hour 1 :tz -1}))))
+    (is (= #::cd{:tz -1}
+           (sut/to-tz #::cd{:hour 1 :tz 0} -1)))
+    (is (= #::cd{:hour 1 :tz -1}
+           (sut/to-tz #::cd{:hour 1} -1)))))
 
-;; (deftest comparison-operators-test
-;;   (testing "="
-;;     (is (sut/eq? {:year 2011 :month 1 :day 1 :hour 0}))
-;;     (is (not (sut/eq? {:year 2011 :month 1 :day 2 :hour 0}
-;;                       {:year 2011 :month 1 :day 1 :hour 0})))
-;;     (is (sut/eq? {:year 2011 :month 1 :day 1 :hour 1}
-;;                  {:year 2011 :month 1 :day 1 :hour 1}))
-;;     (is (not (sut/eq? {:year 2011 :month 1 :day 1 :hour 0}
-;;                       {:year 2011 :month 1 :day 2 :hour 0}
-;;                       {:year 2011 :month 1 :day 1 :hour 0})))
-;;     (is (sut/eq? {:year 2011 :month 1 :day 1 :hour 0}
-;;                  {:year 2011 :month 1 :day 1 :hour 0}
-;;                  {:year 2011 :month 1 :day 1 :hour 0})))
-;;   (testing "= with utc-offset"
-;;     (is (sut/eq? {:hour 10 :min 10} {:hour 13 :min 10 :tz 3}))
-;;     (is (not (sut/eq? {:hour 13 :min 10} {:hour 13 :min 10 :tz 3})))
-;;     (is (sut/eq? {:hour 210 :min 10} {:hour 213 :min 10 :tz 3}))
-;;     (is (sut/eq? {:hour 15 :min 10} {:hour 13 :min 10 :tz -2}))
-;;     (is (sut/eq? {:hour 12 :min 10 :tz 2} {:hour 13 :min 10 :tz 3}))
-;;     (is (sut/eq? {:hour 10 :min 10} {:hour 12 :min 10 :tz 2})))
-;;   (testing "not="
-;;     (is (not (sut/not-eq? {:year 2011 :month 1 :day 1 :hour 0})))
-;;     (is (not (sut/not-eq? {:year 2011 :month 1 :day 1 :hour 0}
-;;                           {:year 2011 :month 1 :day 1 :hour 0})))
-;;     (is (sut/not-eq? {:year 2011 :month 1 :day 2 :hour 1}
-;;                      {:year 2011 :month 1 :day 1 :hour 1}))
-;;     (is (not (sut/not-eq? {:year 2011 :month 1 :day 1 :hour 0}
-;;                           {:year 2011 :month 1 :day 1 :hour 0}
-;;                           {:year 2011 :month 1 :day 1 :hour 0})))
-;;     (is (sut/not-eq? {:year 2011 :month 1 :day 1 :hour 0}
-;;                      {:year 2011 :month 1 :day 2 :hour 0}
-;;                      {:year 2011 :month 1 :day 1 :hour 0})))
-;;   (testing "not= with utc-offset"
-;;     (is (not (sut/not-eq? {:hour 10 :min 10} {:hour 13 :min 10 :tz 3})))
-;;     (is (sut/not-eq? {:hour 13 :min 10} {:hour 13 :min 10 :tz 3}))
-;;     (is (not (sut/not-eq? {:hour 210 :min 10} {:hour 213 :min 10 :tz 3})))
-;;     (is (not (sut/not-eq? {:hour 15 :min 10} {:hour 13 :min 10 :tz -2})))
-;;     (is (not (sut/not-eq? {:hour 12 :min 10 :tz 2} {:hour 13 :min 10 :tz 3})))
-;;     (is (not (sut/not-eq? {:hour 10 :min 10} {:hour 12 :min 10 :tz 2}))))
-;;   (testing ">"
-;;     (is (sut/gt {:year 2011 :month 1 :day 1 :hour 0}))
-;;     (is (sut/gt {:min 120} {:hour 1}))
-;;     (is (not (sut/gt {:year 2011 :month 1 :day 1 :hour 0}
-;;                      {:year 2011 :month 1 :day 2 :hour 0})))
-;;     (is (sut/gt {:year 2011 :month 1 :day 2 :hour 0}
-;;                 {:year 2011 :month 1 :day 1 :hour 0}))
-;;     (is (sut/gt {:year 2011 :month 1 :day 2 :hour 0}
-;;                 {:year 2011 :month 1 :day 1 :hour 1}
-;;                 {:year 2011 :month 1 :day 1 :hour 0})))
-;;   (testing "> with utc-offset"
-;;     (is (sut/gt {:hour 13} {:hour 13 :tz 3}))
-;;     (is (not (sut/gt {:hour 13 :tz 3} {:hour 13})))
-;;     (is (sut/gt {:hour 13 :tz -3} {:hour 13}))
-;;     (is (not (sut/gt {:hour 13} {:hour 13 :tz -3})))
-;;     (is (sut/gt {:hour 13 :tz -3} {:hour 13 :tz -2}))
-;;     (is (not (sut/gt {:hour 13 :tz -2} {:hour 13 :tz -3})))
-;;     (is (not (sut/gt {:hour 10 :min 10} {:hour 13 :min 10 :tz 3}))))
-;;   (testing "<"
-;;     (is (sut/lt {:year 2011 :month 1 :day 1 :hour 0}))
-;;     (is (sut/lt {:hour 1} {:min 120}))
-;;     (is (not (sut/lt {:year 2011 :month 1 :day 2 :hour 0}
-;;                      {:year 2011 :month 1 :day 1 :hour 0})))
-;;     (is (sut/lt {:year 2011 :month 1 :day 1 :hour 0}
-;;                 {:year 2011 :month 1 :day 2 :hour 0}))
-;;     (is (sut/lt {:year 2011 :month 1 :day 1 :hour 0}
-;;                 {:year 2011 :month 1 :day 1 :hour 1}
-;;                 {:year 2011 :month 1 :day 2 :hour 0})))
-;;   (testing "< with utc-offset"
-;;     (is (sut/lt {:hour 13 :tz 3} {:hour 13}))
-;;     (is (not (sut/lt {:hour 13} {:hour 13 :tz 3})))
-;;     (is (sut/lt {:hour 13} {:hour 13 :tz -3}))
-;;     (is (not (sut/lt {:hour 13 :tz -3} {:hour 13})))
-;;     (is (sut/lt {:hour 13 :tz -2} {:hour 13 :tz -3}))
-;;     (is (not (sut/lt {:hour 13 :tz -3} {:hour 13 :tz -2})))
-;;     (is (not (sut/lt {:hour 13 :min 10 :tz 3} {:hour 10 :min 10}))))
-;;   (testing "<="
-;;     (is (sut/lte {:year 2011 :month 1 :day 1 :hour 0}))
-;;     (is (sut/lte {:year 2011 :month 1 :day 1 :hour 0}
-;;                  {:year 2011 :month 1 :day 2 :hour 0}))
-;;     (is (sut/lte {:year 2011 :month 1 :day 1 :hour 0}
-;;                  {:year 2011 :month 1 :day 1 :hour 0}))
-;;     (is (not (sut/lte {:year 2011 :month 1 :day 2 :hour 0}
-;;                       {:year 2011 :month 1 :day 1 :hour 0})))
-;;     (is (sut/lte {:year 2011 :month 1 :day 1 :hour 0}
-;;                  {:year 2011 :month 1 :day 1 :hour 0}
-;;                  {:year 2011 :month 1 :day 2 :hour 0})))
-;;   (testing ">="
-;;     (is (sut/gte {:year 2011 :month 1 :day 1 :hour 0}))
-;;     (is (sut/gte {:year 2011 :month 1 :day 2 :hour 0}
-;;                  {:year 2011 :month 1 :day 1 :hour 0}))
-;;     (is (sut/gte {:year 2011 :month 1 :day 2 :hour 1}
-;;                  {:year 2011 :month 1 :day 1 :hour 1}
-;;                  {:year 2011 :month 1 :day 1 :hour 0}))
-;;     (is (not (sut/gte {:year 2011 :month 1 :day 1 :hour 0}
-;;                       {:year 2011 :month 1 :day 2 :hour 0})))
-;;     (is (sut/gte {:year 2011 :month 1 :day 2 :hour 0}
-;;                  {:year 2011 :month 1 :day 1 :hour 0}
-;;                  {:year 2011 :month 1 :day 1 :hour 0}))))
+(deftest comparison-operators-test
+  (testing "="
+    (is (sut/eq? #::cd{:year 2011 :month 1 :day 1 :hour 0}))
+    (is (not (sut/eq? #::cd{:year 2011 :month 1 :day 2 :hour 0}
+                      #::cd{:year 2011 :month 1 :day 1 :hour 0})))
+    (is (sut/eq? #::cd{:year 2011 :month 1 :day 1 :hour 1}
+                 #::cd{:year 2011 :month 1 :day 1 :hour 1}))
+    (is (not (sut/eq? #::cd{:year 2011 :month 1 :day 1 :hour 0}
+                      #::cd{:year 2011 :month 1 :day 2 :hour 0}
+                      #::cd{:year 2011 :month 1 :day 1 :hour 0})))
+    (is (sut/eq? #::cd{:year 2011 :month 1 :day 1 :hour 0}
+                 #::cd{:year 2011 :month 1 :day 1 :hour 0}
+                 #::cd{:year 2011 :month 1 :day 1 :hour 0})))
+  (testing "= with utc-offset"
+    (is (sut/eq? #::cd{:hour 10 :min 10} #::cd{:hour 13 :min 10 :tz 3}))
+    (is (not (sut/eq? #::cd{:hour 13 :min 10} #::cd{:hour 13 :min 10 :tz 3})))
+    (is (sut/eq? #::cd{:hour 210 :min 10} #::cd{:hour 213 :min 10 :tz 3}))
+    (is (sut/eq? #::cd{:hour 15 :min 10} #::cd{:hour 13 :min 10 :tz -2}))
+    (is (sut/eq? #::cd{:hour 12 :min 10 :tz 2} #::cd{:hour 13 :min 10 :tz 3}))
+    (is (sut/eq? #::cd{:hour 10 :min 10} #::cd{:hour 12 :min 10 :tz 2}))
+    (is (not (sut/eq? #::cd{:hour 5 :min 30} #::ci{:hour 5 :min 30}))))
+  (testing "not="
+    (is (not (sut/not-eq? #::cd{:year 2011 :month 1 :day 1 :hour 0})))
+    (is (not (sut/not-eq? #::cd{:year 2011 :month 1 :day 1 :hour 0}
+                          #::cd{:year 2011 :month 1 :day 1 :hour 0})))
+    (is (sut/not-eq? #::cd{:year 2011 :month 1 :day 2 :hour 1}
+                     #::cd{:year 2011 :month 1 :day 1 :hour 1}))
+    (is (not (sut/not-eq? #::cd{:year 2011 :month 1 :day 1 :hour 0}
+                          #::cd{:year 2011 :month 1 :day 1 :hour 0}
+                          #::cd{:year 2011 :month 1 :day 1 :hour 0})))
+    (is (sut/not-eq? #::cd{:year 2011 :month 1 :day 1 :hour 0}
+                     #::cd{:year 2011 :month 1 :day 2 :hour 0}
+                     #::cd{:year 2011 :month 1 :day 1 :hour 0})))
+  (testing "not= with utc-offset"
+    (is (not (sut/not-eq? #::cd{:hour 10 :min 10} #::cd{:hour 13 :min 10 :tz 3})))
+    (is (sut/not-eq? #::cd{:hour 13 :min 10} #::cd{:hour 13 :min 10 :tz 3}))
+    (is (not (sut/not-eq? #::cd{:hour 210 :min 10} #::cd{:hour 213 :min 10 :tz 3})))
+    (is (not (sut/not-eq? #::cd{:hour 15 :min 10} #::cd{:hour 13 :min 10 :tz -2})))
+    (is (not (sut/not-eq? #::cd{:hour 12 :min 10 :tz 2} #::cd{:hour 13 :min 10 :tz 3})))
+    (is (not (sut/not-eq? #::cd{:hour 10 :min 10} #::cd{:hour 12 :min 10 :tz 2}))))
+  (testing ">"
+    (is (sut/gt #::cd{:year 2011 :month 1 :day 1 :hour 0}))
+    (is (sut/gt #::ci{:min 120} #::ci{:hour 1}))
+    (is (not (sut/gt #::cd{:year 2011 :month 1 :day 1 :hour 0}
+                     #::cd{:year 2011 :month 1 :day 2 :hour 0})))
+    (is (sut/gt #::cd{:year 2011 :month 1 :day 2 :hour 0}
+                #::cd{:year 2011 :month 1 :day 1 :hour 0}))
+    (is (sut/gt #::cd{:year 2011 :month 1 :day 2 :hour 0}
+                #::cd{:year 2011 :month 1 :day 1 :hour 1}
+                #::cd{:year 2011 :month 1 :day 1 :hour 0}))
+    (is (sut/gt #::ci{:hour 1} #::ci{:min 55})))
+  (testing "> with utc-offset"
+    (is (sut/gt #::cd{:hour 13} #::cd{:hour 13 :tz 3}))
+    (is (not (sut/gt #::cd{:hour 13 :tz 3} #::cd{:hour 13})))
+    (is (sut/gt #::cd{:hour 13 :tz -3} #::cd{:hour 13}))
+    (is (not (sut/gt #::cd{:hour 13} #::cd{:hour 13 :tz -3})))
+    (is (sut/gt #::cd{:hour 13 :tz -3} #::cd{:hour 13 :tz -2}))
+    (is (not (sut/gt #::cd{:hour 13 :tz -2} #::cd{:hour 13 :tz -3})))
+    (is (not (sut/gt #::cd{:hour 10 :min 10} #::cd{:hour 13 :min 10 :tz 3}))))
+  (testing "<"
+    (is (sut/lt #::cd{:year 2011 :month 1 :day 1 :hour 0}))
+    (is (sut/lt #::cd{:hour 1} #::cd{:min 120}))
+    (is (not (sut/lt #::cd{:year 2011 :month 1 :day 2 :hour 0}
+                     #::cd{:year 2011 :month 1 :day 1 :hour 0})))
+    (is (sut/lt #::cd{:year 2011 :month 1 :day 1 :hour 0}
+                #::cd{:year 2011 :month 1 :day 2 :hour 0}))
+    (is (sut/lt #::cd{:year 2011 :month 1 :day 1 :hour 0}
+                #::cd{:year 2011 :month 1 :day 1 :hour 1}
+                #::cd{:year 2011 :month 1 :day 2 :hour 0})))
+  (testing "< with utc-offset"
+    (is (sut/lt #::cd{:hour 13 :tz 3} #::cd{:hour 13}))
+    (is (not (sut/lt #::cd{:hour 13} #::cd{:hour 13 :tz 3})))
+    (is (sut/lt #::cd{:hour 13} #::cd{:hour 13 :tz -3}))
+    (is (not (sut/lt #::cd{:hour 13 :tz -3} #::cd{:hour 13})))
+    (is (sut/lt #::cd{:hour 13 :tz -2} #::cd{:hour 13 :tz -3}))
+    (is (not (sut/lt #::cd{:hour 13 :tz -3} #::cd{:hour 13 :tz -2})))
+    (is (not (sut/lt #::cd{:hour 13 :min 10 :tz 3} #::cd{:hour 10 :min 10}))))
+  (testing "<="
+    (is (sut/lte #::cd{:year 2011 :month 1 :day 1 :hour 0}))
+    (is (sut/lte #::cd{:year 2011 :month 1 :day 1 :hour 0}
+                 #::cd{:year 2011 :month 1 :day 2 :hour 0}))
+    (is (sut/lte #::cd{:year 2011 :month 1 :day 1 :hour 0}
+                 #::cd{:year 2011 :month 1 :day 1 :hour 0}))
+    (is (not (sut/lte #::cd{:year 2011 :month 1 :day 2 :hour 0}
+                      #::cd{:year 2011 :month 1 :day 1 :hour 0})))
+    (is (sut/lte #::cd{:year 2011 :month 1 :day 1 :hour 0}
+                 #::cd{:year 2011 :month 1 :day 1 :hour 0}
+                 #::cd{:year 2011 :month 1 :day 2 :hour 0})))
+  (testing ">="
+    (is (sut/gte #::cd{:year 2011 :month 1 :day 1 :hour 0}))
+    (is (sut/gte #::cd{:year 2011 :month 1 :day 2 :hour 0}
+                 #::cd{:year 2011 :month 1 :day 1 :hour 0}))
+    (is (sut/gte #::cd{:year 2011 :month 1 :day 2 :hour 1}
+                 #::cd{:year 2011 :month 1 :day 1 :hour 1}
+                 #::cd{:year 2011 :month 1 :day 1 :hour 0}))
+    (is (not (sut/gte #::cd{:year 2011 :month 1 :day 1 :hour 0}
+                      #::cd{:year 2011 :month 1 :day 2 :hour 0})))
+    (is (sut/gte #::cd{:year 2011 :month 1 :day 2 :hour 0}
+                 #::cd{:year 2011 :month 1 :day 1 :hour 0}
+                 #::cd{:year 2011 :month 1 :day 1 :hour 0}))))
 
 (deftest arithmetic-operations-test
   (testing "+"
@@ -343,149 +345,6 @@
     (is (= #::ci{:day 2 :hour 1}
            (sut/minus #::cd{:year 2020 :month 6 :day 7 :hour 15 :min 30 :tz 3}
                       #::cd{:year 2020 :month 6 :day 5 :hour 13 :min 30 :tz 2})))))
-
-;; (deftest arithmetic-operations-test
-;;   (testing "+"
-;;     (def t
-;;       #_{::ch/year  2018
-;;        ::ch/month 1
-;;        ::ch/day   1
-;;        ::ch/hour  12
-;;        ::ch/min   30
-;;        ::ch/sec   30
-;;        ::ch/ms    500})
-
-;;     (matcho/match (sut/plus t {::ch/ms 200})
-;;                   {::ch/ms 700})
-
-;;     #_(matcho/match (sut/plus t {:ms 600})
-;;                   {:ms  100
-;;                    :sec 31})
-
-;;     (is (= (sut/plus {:ms 600} {:ms 600} {:ms 300})
-;;            {:ms  500
-;;             :sec 1}))
-
-;;     (matcho/match (sut/plus t {:sec 20})
-;;                   {:sec 50})
-
-;;     (matcho/match (sut/plus t {:sec 20})
-;;                   {:sec 50})
-
-;;     (matcho/match (sut/plus t {:min 20})
-;;                   {:hour 12
-;;                    :min  50})
-
-;;     (matcho/match (sut/plus t {:min 30})
-;;                   {:hour 13})
-
-;;     (is (= (sut/plus {:year 2018 :month 12 :day 31} {:day 1})
-;;            {:year 2019 :month 1 :day 1}))
-
-;;     (is (= (sut/plus {:year 2018 :month 1 :day 1} {:day 31})
-;;            {:year 2018 :month 2 :day 1}))
-
-;;     (is (= (sut/plus {:year 2018 :month 12 :day 31} {:day 366})
-;;            {:year 2020 :month 1 :day 1}))
-
-;;     (is (= (sut/plus {:year 2018 :month 2 :day 28} {:day 1})
-;;            {:year 2018 :month 3 :day 1}))
-
-;;     (is (= (sut/plus {:year 2018 :month 3 :day 30} {:day 1})
-;;            {:year 2018 :month 3 :day 31}))
-
-;;     (is (= (sut/plus {:year 2018 :month 3 :day 31} {:day 1})
-;;            {:year 2018 :month 4 :day 1}))
-
-;;     (is (= (sut/plus {:ms 100} {:ms 300})
-;;            {:ms 400}))
-
-;;     (is (= (sut/plus {:ms 900} {:ms 300})
-;;            {:ms 200 :sec 1}))
-
-;;     (is (= (sut/plus {:sec 40} {:sec 50})
-;;            {:sec 30 :min 1}))
-
-;;     (is (= (sut/plus {:min 40} {:min 50})
-;;            {:min 30 :hour 1}))
-
-;;     (is (= (sut/plus {:hour 13} {:hour 14})
-;;            {:hour 3 :day 1}))
-
-;;     (is (= (sut/plus {:year 2011 :month 1 :day 1 :hour 23} {:hour 5})
-;;            {:year 2011 :month 1 :day 2 :hour 4}))
-
-;;     (is (= (sut/plus {:year 2011 :month 1 :day 30} {:day 3})
-;;            {:year 2011 :month 2 :day 2}))
-
-;;     (is (= (sut/plus {:year 2011 :month 1 :day 1} {:day 365})
-;;            {:year 2012 :month 1 :day 1}))
-
-;;     (is (= (sut/plus {:year 2011 :month 12 :day 31 :hour 23} {:hour 5})
-;;            {:year 2012 :month 1 :day 1 :hour 4}))
-
-;;     (is (= (sut/plus {:year 2011 :month 1 :day 1 :hour 0} {:hour -1})
-;;            {:year 2010 :month 12 :day 31 :hour 23}))
-
-;;     (is (= (sut/plus {:year 2011 :month 1 :day 1 :hour 0} {:sec -1})
-;;            {:year 2010 :month 12 :day 31 :hour 23 :min 59 :sec 59}))
-
-;;     (is (= (sut/plus {:year 2011 :month 1 :day 1 :hour 0} {:ms -1})
-;;            {:year 2010 :month 12 :day 31 :hour 23 :min 59 :sec 59 :ms 999}))
-
-;;     (is (= (sut/plus {:year 2011 :month 1 :day 1 :hour 23} {:hour -23 :min -30})
-;;            {:year 2010 :month 12 :day 31 :hour 23 :min 30}))
-
-;;     (is (= (sut/plus {:year 2019 :month 11 :day 1} {:month 1})
-;;            {:year 2019 :month 12 :day 1}))
-
-;;     (is (= (sut/plus {:year 2019 :month 11 :day 1} {:month 2})
-;;            {:year 2020 :month 1 :day 1}))
-
-;;     (is (= (sut/plus {:year 2019 :month 12 :day 1} {:month 1})
-;;            {:year 2020 :month 1 :day 1}))
-
-;;     (is (= (sut/plus {:year 2019 :month 11 :day 32} {:month 1})
-;;            {:year 2020 :month 1 :day 1}))
-
-;;     (is (= (sut/plus {:year 2019, :month 12, :day 10, :hour 13, :min 17, :sec 50, :ms 911} {:hour 2})
-;;            {:year 2019, :month 12, :day 10, :hour 15, :min 17, :sec 50, :ms 911}))
-
-;;     (is (= (sut/plus {:hour 4 :tz 2} {:hour 10})
-;;            {:hour 14 :tz 2}))
-
-;;     (is (= (sut/plus {:hour 23 :tz -2} {:hour 1})
-;;            {:day 1 :tz -2}))
-
-;;     (is (= (sut/plus {:hour 1 :tz -2} {:hour 1})
-;;            {:hour 2 :tz -2}))
-
-;;     (testing "with custom units"
-;;       (def normalize-ns (sut/gen-norm :ns :ms 1000000 0))
-;;       (defmethod sut/normalize-rule :ns [_ t] (normalize-ns t))
-
-;;       (is (= (sut/plus {:ns 10} {:ns 1})
-;;              {:ns 11}))
-
-;;       (is (= (sut/plus {:ns 999999999} {:ns 1})
-;;              {:sec 1}))
-
-;;       (is (= (sut/plus {:ns 9999999} {:ns 999000001})
-;;              {:sec 1 :ms 9}))
-
-;;       (is (= (sut/plus {:year 2019 :month 12 :day 31 :hour 23 :min 59 :sec 59 :ns 999999999} {:ns 1})
-;;              {:year 2020 :month 1 :day 1}))))
-
-;;   (testing "-"
-;;     (is (= (sut/minus {:year 2016 :month 12 :day 31 :hour 23 :min 30} {:day 365})
-;;            {:year 2016, :month 1, :day 1, :hour 23, :min 30}))
-
-;;     (is (= (sut/minus {:year 2016 :month 12 :day 31 :hour 23 :min 30} {:day 366})
-;;            {:year 2015, :month 12, :day 31, :hour 23, :min 30}))
-;;     (is (= (sut/minus {:hour 2 :tz -2} {:hour 2})
-;;            {:tz -2}))
-;;     (is (= (sut/minus {:hour 3 :tz 2} {:hour 1 :tz 2})
-;;            {:hour 2 :tz 2}))))
 
 (deftest test-timezones
   (testing "tz comparison"

--- a/test/chrono/ops_test.clj
+++ b/test/chrono/ops_test.clj
@@ -184,7 +184,11 @@
        ::ch/ms    500})
 
     (matcho/match (sut/plus t {::ci/ms 200})
-                  {::ch/ms 700})))
+                  {::ch/ms 700})
+
+    (matcho/match (sut/plus t {::ci/ms 600})
+                  {::ch/ms  100
+                   ::ch/sec 31})))
 
 ;; (deftest arithmetic-operations-test
 ;;   (testing "+"

--- a/test/chrono/ops_test.clj
+++ b/test/chrono/ops_test.clj
@@ -72,7 +72,7 @@
     (is (= (sut/to-tz {:hour 1} -1)
            {:hour 1 :tz -1}))))
 
-(deftest comparsion-operators-test
+(deftest comparison-operators-test
   (testing "="
     (is (sut/eq? {:year 2011 :month 1 :day 1 :hour 0}))
     (is (not (sut/eq? {:year 2011 :month 1 :day 2 :hour 0}
@@ -315,7 +315,7 @@
            {:hour 2 :tz 2}))))
 
 (deftest test-timezones
-  (testing "tz comparsion"
+  (testing "tz comparison"
     (is (sut/lte {:year 2018 :month 5 :day 2 :hour 14 :tz :ny}
                  {:year 2018 :month 5 :day 2 :hour 14 :tz :ny}))
 

--- a/test/chrono/ops_test.clj
+++ b/test/chrono/ops_test.clj
@@ -316,7 +316,21 @@
 
       (is (= #::cd{:year 2020 :month 1 :day 1}
              (sut/plus #::cd{:year 2019 :month 12 :day 31 :hour 23 :min 59 :sec 59 :ns 999999999}
-                       #::ci{:ns 1}))))))
+                       #::ci{:ns 1})))))
+
+  (testing "-"
+    (is (= #::cd{:year 2016, :month 1, :day 1, :hour 23, :min 30}
+           (sut/minus #::cd{:year 2016 :month 12 :day 31 :hour 23 :min 30}
+                      #::ci{:day 365})))
+
+    (is (= #::cd{:year 2015, :month 12, :day 31, :hour 23, :min 30}
+           (sut/minus #::cd{:year 2016 :month 12 :day 31 :hour 23 :min 30}
+                      #::ci{:day 366})))
+    (is (= #::cd{:tz -2}
+           (sut/minus #::cd{:hour 2 :tz -2} #::ci{:hour 2})))
+    (is (= #::ci{:day 2 :hour 2}
+           (sut/minus #::cd{:year 2020 :month 6 :day 7 :hour 15 :min 30 :tz 3}
+                      #::cd{:year 2020 :month 6 :day 5 :hour 13 :min 30 :tz 3})))))
 
 ;; (deftest arithmetic-operations-test
 ;;   (testing "+"

--- a/test/chrono/ops_test.clj
+++ b/test/chrono/ops_test.clj
@@ -188,7 +188,11 @@
 
     (matcho/match (sut/plus t {::ci/ms 600})
                   {::cd/ms  100
-                   ::cd/sec 31})))
+                   ::cd/sec 31})
+
+    (is (= {::ci/ms  500
+            ::ci/sec 1}
+           (sut/plus {::ci/ms 600} {::ci/ms 600} {::ci/ms 300})))))
 
 ;; (deftest arithmetic-operations-test
 ;;   (testing "+"

--- a/test/chrono/ops_test.clj
+++ b/test/chrono/ops_test.clj
@@ -475,62 +475,62 @@
 ;;     (is (= (sut/minus {:hour 3 :tz 2} {:hour 1 :tz 2})
 ;;            {:hour 2 :tz 2}))))
 
-;; (deftest test-timezones
-;;   (testing "tz comparison"
-;;     (is (sut/lte {:year 2018 :month 5 :day 2 :hour 14 :tz :ny}
-;;                  {:year 2018 :month 5 :day 2 :hour 14 :tz :ny}))
+(deftest test-timezones
+  (testing "tz comparison"
+    (is (sut/lte #::cd{:year 2018 :month 5 :day 2 :hour 14 :tz :ny}
+                 #::cd{:year 2018 :month 5 :day 2 :hour 14 :tz :ny}))
 
-;;     (is (sut/lte {:year 2018 :month 5 :day 2 :hour 14 :tz :ny}
-;;                  {:year 2018 :month 5 :day 2 :hour 14 :sec 1 :tz :ny}))
+    (is (sut/lte #::cd{:year 2018 :month 5 :day 2 :hour 14 :tz :ny}
+                 #::cd{:year 2018 :month 5 :day 2 :hour 14 :sec 1 :tz :ny}))
 
-;;     (is (sut/gt {:year 2018 :month 5 :day 2 :hour 14 :sec 1 :tz :ny}
-;;                 {:year 2018 :month 5 :day 2 :hour 14 :tz :ny}))
+    (is (sut/gt #::cd{:year 2018 :month 5 :day 2 :hour 14 :sec 1 :tz :ny}
+                #::cd{:year 2018 :month 5 :day 2 :hour 14 :tz :ny}))
 
-;;     (is (sut/gt {:year 2018 :month 5 :day 2 :hour 13 :min 120 :tz :ny}
-;;                 {:year 2018 :month 5 :day 2 :hour 14 :tz :ny}))
+    (is (sut/gt #::cd{:year 2018 :month 5 :day 2 :hour 13 :min 120 :tz :ny}
+                #::cd{:year 2018 :month 5 :day 2 :hour 14 :tz :ny}))
 
-;;     (is (sut/lte {:year 2018 :month 5 :day 2 :hour 14 :tz :ny}
-;;                  {:year 2018 :month 5 :day 2 :hour 13 :min 120 :tz :ny}))
+    (is (sut/lte #::cd{:year 2018 :month 5 :day 2 :hour 14 :tz :ny}
+                 #::cd{:year 2018 :month 5 :day 2 :hour 13 :min 120 :tz :ny}))
 
-;;     (is (sut/lte {:year 2018 :month 5 :day 2 :hour 14 :tz :ny}
-;;                  {:year 2018 :month 11}))
+    (is (sut/lte #::cd{:year 2018 :month 5 :day 2 :hour 14 :tz :ny}
+                 #::cd{:year 2018 :month 11}))
 
-;;     (is (sut/gt {:year 2018 :month 11}
-;;                 {:year 2018 :month 5 :day 2 :hour 14 :tz :ny})))
+    (is (sut/gt #::cd{:year 2018 :month 11}
+                #::cd{:year 2018 :month 5 :day 2 :hour 14 :tz :ny})))
 
-;;   (matcho/match (sut/day-saving :ny 2017)
-;;                 {:in  {:month 3 :day 12 :hour 2 :min 0}
-;;                  :out {:month 11 :day 5 :hour 2}})
+  (matcho/match (sut/day-saving :ny 2017)
+                {:in  #::cd{:month 3 :day 12 :hour 2 :min 0}
+                 :out #::cd{:month 11 :day 5 :hour 2}})
 
-;;   (matcho/match (sut/day-saving-with-utc :ny 2017)
-;;                 {:in     {:month 3 :day 12 :hour 2 :min 0}
-;;                  :in-utc {:month 3 :day 12 :hour 7}
+  (matcho/match (sut/day-saving-with-utc :ny 2017)
+                {:in     #::cd{:month 3 :day 12 :hour 2 :min 0}
+                 :in-utc #::cd{:month 3 :day 12 :hour 7}
 
-;;                  :out     {:month 11 :day 5 :hour 2}
-;;                  :out-utc {:month 11 :day 5 :hour 6}})
+                 :out     #::cd{:month 11 :day 5 :hour 2}
+                 :out-utc #::cd{:month 11 :day 5 :hour 6}})
 
-;;   (matcho/match (sut/day-saving-with-utc :ny 2018)
-;;                 {:in  {:month 3 :day 11}
-;;                  :out {:month 11 :day 4}})
+  (matcho/match (sut/day-saving-with-utc :ny 2018)
+                {:in  #::cd{:month 3 :day 11}
+                 :out #::cd{:month 11 :day 4}})
 
-;;   (matcho/match (sut/day-saving-with-utc :ny 2019)
-;;                 {:in  {:month 3 :day 10}
-;;                  :out {:month 11 :day 3}})
+  (matcho/match (sut/day-saving-with-utc :ny 2019)
+                {:in  #::cd{:month 3 :day 10}
+                 :out #::cd{:month 11 :day 3}})
 
-;;   (is (= (sut/to-utc {:year 2018 :month 5 :day 2 :hour 14 :tz :ny})
-;;          {:year 2018 :month 5 :day 2 :hour 18 :tz 0}))
+  (is (= #::cd{:year 2018 :month 5 :day 2 :hour 18 :tz 0}
+         (sut/to-utc #::cd{:year 2018 :month 5 :day 2 :hour 14 :tz :ny})))
 
-;;   (is (= (sut/to-tz {:year 2018 :month 5 :day 2 :hour 18 :tz 0} :ny)
-;;          {:year 2018 :month 5 :day 2 :hour 14 :tz :ny}))
+  (is (= #::cd{:year 2018 :month 5 :day 2 :hour 14 :tz :ny}
+         (sut/to-tz #::cd{:year 2018 :month 5 :day 2 :hour 18 :tz 0} :ny)))
 
-;;   (is (= (sut/to-tz {:year 2018 :month 5 :day 2 :hour 18} :ny)
-;;          {:year 2018 :month 5 :day 2 :hour 18 :tz :ny}))
+  (is (= #::cd{:year 2018 :month 5 :day 2 :hour 18 :tz :ny}
+         (sut/to-tz #::cd{:year 2018 :month 5 :day 2 :hour 18} :ny)))
 
-;;   (is (= (sut/to-utc {:year 2018 :month 2 :day 2 :hour 14 :tz :ny})
-;;          {:year 2018 :month 2 :day 2 :hour 19 :tz 0}))
+  (is (= #::cd{:year 2018 :month 2 :day 2 :hour 19 :tz 0}
+         (sut/to-utc #::cd{:year 2018 :month 2 :day 2 :hour 14 :tz :ny})))
 
-;;   (is (= (sut/to-tz {:year 2018 :month 2 :day 2 :hour 19 :tz 0} :ny)
-;;          {:year 2018 :month 2 :day 2 :hour 14 :tz :ny}))
+  (is (= #::cd{:year 2018 :month 2 :day 2 :hour 14 :tz :ny}
+         (sut/to-tz #::cd{:year 2018 :month 2 :day 2 :hour 19 :tz 0} :ny)))
 
-;;   (is (= (sut/to-tz {:year 2018 :month 2 :day 2 :hour 19} :ny)
-;;          {:year 2018 :month 2 :day 2 :hour 19 :tz :ny})))
+  (is (= #::cd{:year 2018 :month 2 :day 2 :hour 19 :tz :ny}
+         (sut/to-tz #::cd{:year 2018 :month 2 :day 2 :hour 19} :ny))))

--- a/test/chrono/ops_test.clj
+++ b/test/chrono/ops_test.clj
@@ -296,7 +296,27 @@
 
     (is (= #::cd{:year 2019, :month 12, :day 10, :hour 15, :min 17, :sec 50, :ms 911}
            (sut/plus #::cd{:year 2019, :month 12, :day 10, :hour 13, :min 17, :sec 50, :ms 911}
-                     #::ci{:hour 2})))))
+                     #::ci{:hour 2})))
+
+    (testing "with custom units"
+      (def normalize-cd-ns (sut/gen-norm ::cd/ns ::cd/ms 1000000 0))
+      (def normalize-ci-ns (sut/gen-norm ::ci/ns ::ci/ms 1000000 0))
+
+      (defmethod sut/normalize-rule ::cd/ns [_ t] (normalize-cd-ns t))
+      (defmethod sut/normalize-rule ::ci/ns [_ t] (normalize-ci-ns t))
+
+      (is (= #::ci{:ns 11}
+             (sut/plus #::ci{:ns 10} #::ci{:ns 1})))
+
+      (is (= #::ci{:sec 1}
+             (sut/plus #::ci{:ns 999999999} #::ci{:ns 1})))
+
+      (is (= #::ci{:sec 1 :ms 9}
+             (sut/plus #::ci{:ns 9999999} #::ci{:ns 999000001})))
+
+      (is (= #::cd{:year 2020 :month 1 :day 1}
+             (sut/plus #::cd{:year 2019 :month 12 :day 31 :hour 23 :min 59 :sec 59 :ns 999999999}
+                       #::ci{:ns 1}))))))
 
 ;; (deftest arithmetic-operations-test
 ;;   (testing "+"

--- a/test/chrono/ops_test.clj
+++ b/test/chrono/ops_test.clj
@@ -307,6 +307,9 @@
     (is (= #::cd{:hour 2 :tz -2}
            (sut/plus #::cd{:hour 1 :tz -2} #::ci{:hour 1 :tz 3})))
 
+    (is (= #::cd{:hour 2 :tz -2}
+           (sut/plus #::ci{:hour 1 :tz 3} #::cd{:hour 1 :tz -2})))
+
     (testing "with custom units"
       (def normalize-cd-ns (sut/gen-norm ::cd/ns ::cd/ms 1000000 0))
       (def normalize-ci-ns (sut/gen-norm ::ci/ns ::ci/ms 1000000 0))

--- a/test/chrono/ops_test.clj
+++ b/test/chrono/ops_test.clj
@@ -1,5 +1,5 @@
 (ns chrono.ops-test
-  (:require [chrono.core :as ch]
+  (:require [chrono.datetime :as cd]
             [chrono.interval :as ci]
             [chrono.ops :as sut]
             [clojure.test :refer :all]
@@ -175,20 +175,20 @@
 (deftest arithmetic-operations-test
   (testing "+"
     (def t
-      {::ch/year  2018
-       ::ch/month 1
-       ::ch/day   1
-       ::ch/hour  12
-       ::ch/min   30
-       ::ch/sec   30
-       ::ch/ms    500})
+      {::cd/year  2018
+       ::cd/month 1
+       ::cd/day   1
+       ::cd/hour  12
+       ::cd/min   30
+       ::cd/sec   30
+       ::cd/ms    500})
 
     (matcho/match (sut/plus t {::ci/ms 200})
-                  {::ch/ms 700})
+                  {::cd/ms 700})
 
     (matcho/match (sut/plus t {::ci/ms 600})
-                  {::ch/ms  100
-                   ::ch/sec 31})))
+                  {::cd/ms  100
+                   ::cd/sec 31})))
 
 ;; (deftest arithmetic-operations-test
 ;;   (testing "+"

--- a/test/chrono/ops_test.clj
+++ b/test/chrono/ops_test.clj
@@ -298,6 +298,15 @@
            (sut/plus #::cd{:year 2019, :month 12, :day 10, :hour 13, :min 17, :sec 50, :ms 911}
                      #::ci{:hour 2})))
 
+    (is (= #::cd{:hour 14 :tz 2}
+           (sut/plus #::cd{:hour 4 :tz 2} #::ci{:hour 10})))
+
+    (is (= #::cd{:day 1 :tz -2}
+           (sut/plus #::cd{:hour 23 :tz -2} #::ci{:hour 1})))
+
+    (is (= #::cd{:hour 2 :tz -2}
+           (sut/plus #::cd{:hour 1 :tz -2} #::ci{:hour 1 :tz 3})))
+
     (testing "with custom units"
       (def normalize-cd-ns (sut/gen-norm ::cd/ns ::cd/ms 1000000 0))
       (def normalize-ci-ns (sut/gen-norm ::ci/ns ::ci/ms 1000000 0))
@@ -328,9 +337,9 @@
                       #::ci{:day 366})))
     (is (= #::cd{:tz -2}
            (sut/minus #::cd{:hour 2 :tz -2} #::ci{:hour 2})))
-    (is (= #::ci{:day 2 :hour 2}
+    (is (= #::ci{:day 2 :hour 1}
            (sut/minus #::cd{:year 2020 :month 6 :day 7 :hour 15 :min 30 :tz 3}
-                      #::cd{:year 2020 :month 6 :day 5 :hour 13 :min 30 :tz 3})))))
+                      #::cd{:year 2020 :month 6 :day 5 :hour 13 :min 30 :tz 2})))))
 
 ;; (deftest arithmetic-operations-test
 ;;   (testing "+"

--- a/test/chrono/ops_test.clj
+++ b/test/chrono/ops_test.clj
@@ -192,7 +192,111 @@
 
     (is (= {::ci/ms  500
             ::ci/sec 1}
-           (sut/plus {::ci/ms 600} {::ci/ms 600} {::ci/ms 300})))))
+           (sut/plus {::ci/ms 600} {::ci/ms 600} {::ci/ms 300})))
+
+    (matcho/match (sut/plus t {::ci/sec 20})
+                  {::cd/sec 50})
+
+    (matcho/match (sut/plus t {::ci/sec 20})
+                  {::cd/sec 50})
+
+    (matcho/match (sut/plus t {::ci/min 20})
+                  {::cd/hour 12
+                   ::cd/min  50})
+
+    (matcho/match (sut/plus t {::ci/min 30})
+                  {::cd/hour 13})
+
+    (is (= #::cd{:year 2019 :month 1 :day 1}
+           (sut/plus #::cd{:year 2018 :month 12 :day 31}
+                     #::ci{:day 1})))
+
+    (is (= #::cd{:year 2018 :month 2 :day 1}
+           (sut/plus #::cd{:year 2018 :month 1 :day 1}
+                     #::ci{:day 31})))
+
+    (is (= #::cd{:year 2020 :month 1 :day 1}
+           (sut/plus #::cd{:year 2018 :month 12 :day 31}
+                     #::ci{:day 366})))
+
+    (is (= #::cd{:year 2018 :month 3 :day 1}
+           (sut/plus #::cd{:year 2018 :month 2 :day 28}
+                     #::ci{:day 1})))
+
+    (is (= #::cd{:year 2018 :month 3 :day 31}
+           (sut/plus #::cd{:year 2018 :month 3 :day 30}
+                     #::ci{:day 1})))
+
+    (is (= #::cd{:year 2018 :month 4 :day 1}
+           (sut/plus #::cd{:year 2018 :month 3 :day 31}
+                     #::ci{:day 1})))
+
+    (is (= #::ci{:ms 400}
+           (sut/plus #::ci{:ms 100} #::ci{:ms 300})))
+
+    (is (= #::ci{:ms 200 :sec 1}
+           (sut/plus #::ci{:ms 900} #::ci{:ms 300})))
+
+    (is (= #::ci{:sec 30 :min 1}
+           (sut/plus #::ci{:sec 40} #::ci{:sec 50})))
+
+    (is (= #::ci{:min 30 :hour 1}
+           (sut/plus #::ci{:min 40} #::ci{:min 50})))
+
+    (is (= #::ci{:hour 3 :day 1}
+           (sut/plus #::ci{:hour 13} #::ci{:hour 14})))
+
+    (is (= #::cd{:year 2011 :month 1 :day 2 :hour 4}
+           (sut/plus #::cd{:year 2011 :month 1 :day 1 :hour 23}
+                     #::ci{:hour 5})))
+
+    (is (= #::cd{:year 2011 :month 2 :day 2}
+           (sut/plus #::cd{:year 2011 :month 1 :day 30}
+                     #::ci{:day 3})))
+
+    (is (= #::cd{:year 2012 :month 1 :day 1}
+           (sut/plus #::cd{:year 2011 :month 1 :day 1}
+                     #::ci{:day 365})))
+
+    (is (= #::cd{:year 2012 :month 1 :day 1 :hour 4}
+           (sut/plus #::cd{:year 2011 :month 12 :day 31 :hour 23}
+                     #::ci{:hour 5})))
+
+    (is (= #::cd{:year 2010 :month 12 :day 31 :hour 23}
+           (sut/plus #::cd{:year 2011 :month 1 :day 1 :hour 0}
+                     #::ci{:hour -1})))
+
+    (is (= #::cd{:year 2010 :month 12 :day 31 :hour 23 :min 59 :sec 59}
+           (sut/plus #::cd{:year 2011 :month 1 :day 1 :hour 0}
+                     #::ci{:sec -1})))
+
+    (is (= #::cd{:year 2010 :month 12 :day 31 :hour 23 :min 59 :sec 59 :ms 999}
+           (sut/plus #::cd{:year 2011 :month 1 :day 1 :hour 0}
+                     #::ci{:ms -1})))
+
+    (is (= #::cd{:year 2010 :month 12 :day 31 :hour 23 :min 30}
+           (sut/plus #::cd{:year 2011 :month 1 :day 1 :hour 23}
+                     #::ci{:hour -23 :min -30})))
+
+    (is (= #::cd{:year 2019 :month 12 :day 1}
+           (sut/plus #::cd{:year 2019 :month 11 :day 1}
+                     #::ci{:month 1})))
+
+    (is (= #::cd{:year 2020 :month 1 :day 1}
+           (sut/plus #::cd{:year 2019 :month 11 :day 1}
+                     #::ci{:month 2})))
+
+    (is (= #::cd{:year 2020 :month 1 :day 1}
+           (sut/plus #::cd{:year 2019 :month 12 :day 1}
+                     #::ci{:month 1})))
+
+    (is (= #::cd{:year 2020 :month 1 :day 1}
+           (sut/plus #::cd{:year 2019 :month 11 :day 32}
+                     #::ci{:month 1})))
+
+    (is (= #::cd{:year 2019, :month 12, :day 10, :hour 15, :min 17, :sec 50, :ms 911}
+           (sut/plus #::cd{:year 2019, :month 12, :day 10, :hour 13, :min 17, :sec 50, :ms 911}
+                     #::ci{:hour 2})))))
 
 ;; (deftest arithmetic-operations-test
 ;;   (testing "+"

--- a/test/chrono/tz_test.clj
+++ b/test/chrono/tz_test.clj
@@ -1,24 +1,45 @@
 (ns chrono.tz-test
   (:require [chrono.tz]
             [chrono.ops :as sut]
+            [chrono.datetime :as cd]
             [clojure.test :refer :all]
             [matcho.core :as matcho]))
+
+(deftest test-ny-daysaving
+  (matcho/match (sut/day-saving :ny 2017)
+                {:in  #::cd{:month 3 :day 12 :hour 2 :min 0}
+                 :out #::cd{:month 11 :day 5 :hour 2}})
+
+  (matcho/match (sut/day-saving-with-utc :ny 2017)
+                {:in     #::cd{:month 3 :day 12 :hour 2 :min 0}
+                 :in-utc #::cd{:month 3 :day 12 :hour 7}
+
+                 :out     #::cd{:month 11 :day 5 :hour 2}
+                 :out-utc #::cd{:month 11 :day 5 :hour 6}})
+
+  (matcho/match (sut/day-saving-with-utc :ny 2018)
+                {:in  #::cd{:month 3 :day 11}
+                 :out #::cd{:month 11 :day 4}})
+
+  (matcho/match (sut/day-saving-with-utc :ny 2019)
+                {:in  #::cd{:month 3 :day 10}
+                 :out #::cd{:month 11 :day 3}}))
 
 (deftest test-ny-daysaving-with-utc
   (matcho/match
    (sut/day-saving-with-utc :ny 2017)
-   {:in     {:month 3 :day 12 :hour 2 :min 0}
-    :in-utc {:month 3 :day 12 :hour 7}
+   {:in     #::cd{:month 3 :day 12 :hour 2 :min 0}
+    :in-utc #::cd{:month 3 :day 12 :hour 7}
 
-    :out     {:month 11 :day 5 :hour 2}
-    :out-utc {:month 11 :day 5 :hour 6}})
+    :out     #::cd{:month 11 :day 5 :hour 2}
+    :out-utc #::cd{:month 11 :day 5 :hour 6}})
 
   (matcho/match
    (sut/day-saving-with-utc :ny 2018)
-   {:in  {:month 3 :day 11}
-    :out {:month 11 :day 4}})
+   {:in  #::cd{:month 3 :day 11}
+    :out #::cd{:month 11 :day 4}})
 
   (matcho/match
    (sut/day-saving-with-utc :ny 2019)
-   {:in  {:month 3 :day 10}
-    :out {:month 11 :day 3}}))
+   {:in  #::cd{:month 3 :day 10}
+    :out #::cd{:month 11 :day 3}}))

--- a/test/chrono/util_test.clj
+++ b/test/chrono/util_test.clj
@@ -1,6 +1,7 @@
 (ns chrono.util-test
   (:require [clojure.test :refer :all]
             [chrono.util :as sut]
+            [chrono.datetime :as cd]
             [matcho.core :as matcho])
   (:import [java.util Date]))
 
@@ -16,15 +17,15 @@
 
   (doseq [m (range 1 13)
           y (range 100)]
-    (doseq [d (range 1 (inc (sut/days-in-month {:year (+ 2000 y), :month m})))]
+    (doseq [d (range 1 (inc (sut/days-in-month #::cd{:year (+ 2000 y), :month m})))]
       (let [y (+ 2000 y)
             ref (.getDay (Date. (- y 1900) (dec m) d))
             sam (sut/day-of-week y m d)]
         (when-not (= sam ref)
           (throw (Exception. (pr-str y "-" m "-" d " " "sam" sam " ref " ref)))))))
 
-  (is (=  31 (sut/days-in-month {:year 2018, :month 1})))
-  (is (=  28 (sut/days-in-month {:year 2018, :month 2})))
+  (is (=  31 (sut/days-in-month #::cd{:year 2018, :month 1})))
+  (is (=  28 (sut/days-in-month #::cd{:year 2018, :month 2})))
 
   (doseq [y [1960 1964 1968	1972 1976
              1980 1984 1988	1992 1996
@@ -46,7 +47,7 @@
                  "JUNE" 6}
           test-fn (fn [[inp res]]
                     (testing (str "parsing: " inp)
-                      (is (= (sut/parse-name inp :month nil) res))))]
+                      (is (= (sut/parse-name inp ::cd/month nil) res))))]
       (doall
        (map test-fn cases)))))
 


### PR DESCRIPTION
This PR introduces a concept of types: datetime type and interval type.

This is implemented via namespaced keys - `:chrono.datetime/year`, `:chrono.datetime/month` etc for datetime values and `:chrono.interval/day`, `:chrono.interval/hour` etc for intervals.

Intervals don't support units larger than `day` since `month` and `year` duration in days depends on the context we don't have inside the interval value:

``` clj
(+ #::chrono.datetime{:year 2020 :month 2 :day 28}
   #::chrono.interval{:month 1}) ;; 1 month = 28 days

(+ #::chrono.datetime{:year 2020 :month 3 :day 28}
   #::chrono.interval{:month 1}) ;; 1 month = 31 days
```

Addition now requires at most one datetime argument; other arguments must be intervals since we can't add a date to another date.

Subtraction allows any argument combinations except subtracting a datetime from an interval.

`parse` and `format` functions fully support both types but `format` doesn't apply any zero padding by default (you can still use custom padding length parameter, like `[:chrono.interval/hour 2]`).

Closes #22.